### PR TITLE
Add Azure OpenAI provider support

### DIFF
--- a/markdown-sheet/src/App.tsx
+++ b/markdown-sheet/src/App.tsx
@@ -1697,6 +1697,7 @@ function App() {
             )}
             <MarkdownPreview
               content={content}
+              filePath={activeFile}
               previewRef={previewRef}
               aiSettings={aiSettings}
               onUpdateMermaidBlock={handleUpdateMermaidBlock}

--- a/markdown-sheet/src/components/MarkdownPreview.tsx
+++ b/markdown-sheet/src/components/MarkdownPreview.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useRef, useState } from "react";
 import type { AiSettings } from "../types";
 import { callAI } from "../lib/callAI";
 import { marked } from "marked";
+import { readFile } from "@tauri-apps/plugin-fs";
 import hljs from "highlight.js";
 import "highlight.js/styles/atom-one-dark.css";
 import mermaid from "mermaid";
@@ -131,6 +132,7 @@ const FONT_MAP: Record<string, string> = {
 
 interface Props {
   content: string;
+  filePath?: string | null;
   previewRef?: React.RefObject<HTMLDivElement | null>;
   aiSettings?: AiSettings;
   onUpdateMermaidBlock?: (blockIndex: number, newSource: string) => void;
@@ -138,6 +140,7 @@ interface Props {
 
 const MarkdownPreview: FC<Props> = ({
   content,
+  filePath,
   previewRef: externalRef,
   aiSettings,
   onUpdateMermaidBlock,
@@ -196,10 +199,58 @@ const MarkdownPreview: FC<Props> = ({
   // HTML を mdContentRef に手動で書き込む。
   // dangerouslySetInnerHTML を使わないことで React の reconciliation から切り離し、
   // StrictMode の remount 時に innerHTML がリセットされる問題を回避する。
+  // また、相対画像パスをローカルファイルから blob URL に変換する。
+  const blobUrlsRef = useRef<string[]>([]);
   useEffect(() => {
+    // 前回の blob URL を解放
+    for (const url of blobUrlsRef.current) URL.revokeObjectURL(url);
+    blobUrlsRef.current = [];
+
     const div = mdContentRef.current;
-    if (div) div.innerHTML = html;
-  }, [html]);
+    if (!div) return;
+    div.innerHTML = html;
+
+    if (!filePath) return;
+    const dir = filePath.replace(/[\\/][^\\/]+$/, "");
+    const imgs = Array.from(div.querySelectorAll<HTMLImageElement>("img"));
+    const blobUrls = blobUrlsRef.current;
+
+    (async () => {
+      for (const img of imgs) {
+        const src = img.getAttribute("src");
+        if (!src) continue;
+        if (/^(https?:|data:|blob:)/i.test(src)) continue;
+
+        // 相対パスを絶対パスに解決
+        const combined = dir.replace(/\\/g, "/") + "/" + src;
+        const parts = combined.split("/");
+        const resolved: string[] = [];
+        for (const p of parts) {
+          if (p === "..") resolved.pop();
+          else if (p !== ".") resolved.push(p);
+        }
+        const absolutePath = resolved.join("/");
+
+        try {
+          const data = await readFile(absolutePath);
+          const ext = src.split(".").pop()?.toLowerCase() ?? "";
+          const mime =
+            ext === "svg" ? "image/svg+xml" :
+            ext === "png" ? "image/png" :
+            ext === "gif" ? "image/gif" :
+            ext === "webp" ? "image/webp" :
+            ext === "bmp" ? "image/bmp" :
+            "image/jpeg";
+          const blob = new Blob([data], { type: mime });
+          const url = URL.createObjectURL(blob);
+          blobUrls.push(url);
+          img.src = url;
+        } catch {
+          // ファイルが見つからない場合はスキップ
+        }
+      }
+    })();
+  }, [html, filePath]);
 
   // Mermaid ブロック + KaTeX をレンダリング
   useEffect(() => {

--- a/markdown-sheet/src/components/Settings.tsx
+++ b/markdown-sheet/src/components/Settings.tsx
@@ -82,7 +82,7 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
           },
           body: JSON.stringify({
             messages: [{ role: "user", content: "hi" }],
-            max_tokens: 5,
+            max_completion_tokens: 5,
           }),
         });
         if (resp.ok) {

--- a/markdown-sheet/src/components/Settings.tsx
+++ b/markdown-sheet/src/components/Settings.tsx
@@ -5,7 +5,7 @@ import "./Settings.css";
 const PROVIDERS: {
   id: string;
   label: string;
-  format: "openai" | "anthropic";
+  format: "openai" | "anthropic" | "azure";
   baseUrl: string;
   model: string;
 }[] = [
@@ -14,6 +14,7 @@ const PROVIDERS: {
   { id: "grok",      label: "Grok / xAI (無料枠あり)",   format: "openai",    baseUrl: "https://api.x.ai/v1",                                      model: "grok-2-latest"            },
   { id: "gemini",    label: "Gemini / Google (無料枠あり)", format: "openai", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai/", model: "gemini-2.0-flash"         },
   { id: "openai",    label: "OpenAI (ChatGPT)",           format: "openai",    baseUrl: "https://api.openai.com/v1",                                model: "gpt-4o"                   },
+  { id: "azure",     label: "Azure OpenAI",               format: "azure",     baseUrl: "https://{resource}.openai.azure.com/openai/deployments/{deployment}", model: "gpt-5.1" },
   { id: "anthropic", label: "Claude / Anthropic",         format: "anthropic", baseUrl: "https://api.anthropic.com/v1",                             model: "claude-haiku-4-5-20251001"},
   { id: "custom",    label: "カスタム (さくらのAI など)", format: "openai",    baseUrl: "",                                                         model: ""                         },
 ];
@@ -63,6 +64,25 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
             model: local.model,
             max_tokens: 5,
             messages: [{ role: "user", content: "hi" }],
+          }),
+        });
+        if (resp.ok) {
+          setTestMsg({ text: "接続成功！", ok: true });
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          setTestMsg({ text: `エラー: ${err?.error?.message || resp.statusText}`, ok: false });
+        }
+      } else if (local.apiFormat === "azure") {
+        const url = local.baseUrl.replace(/\/$/, "") + "/chat/completions?api-version=2024-12-01-preview";
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "api-key": local.apiKey,
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "hi" }],
+            max_tokens: 5,
           }),
         });
         if (resp.ok) {
@@ -128,7 +148,7 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
           </select>
 
           <div className="settings-format-badge">
-            形式: <strong>{local.apiFormat === "anthropic" ? "Anthropic Messages API" : "OpenAI 互換"}</strong>
+            形式: <strong>{local.apiFormat === "anthropic" ? "Anthropic Messages API" : local.apiFormat === "azure" ? "Azure OpenAI" : "OpenAI 互換"}</strong>
           </div>
 
           {/* API キー */}
@@ -138,7 +158,7 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
             className="settings-input"
             value={local.apiKey}
             onChange={(e) => { setLocal((s) => ({ ...s, apiKey: e.target.value })); setTestMsg(null); }}
-            placeholder={local.apiFormat === "anthropic" ? "sk-ant-..." : "sk-..."}
+            placeholder={local.apiFormat === "anthropic" ? "sk-ant-..." : local.apiFormat === "azure" ? "Azure API キー" : "sk-..."}
             spellCheck={false}
           />
 

--- a/markdown-sheet/src/lib/callAI.ts
+++ b/markdown-sheet/src/lib/callAI.ts
@@ -41,7 +41,7 @@ export async function callAI(
           { role: "system", content: systemPrompt },
           { role: "user", content: userContent },
         ],
-        max_tokens: 2000,
+        max_completion_tokens: 2000,
       }),
     });
   } else {

--- a/markdown-sheet/src/lib/callAI.ts
+++ b/markdown-sheet/src/lib/callAI.ts
@@ -28,6 +28,22 @@ export async function callAI(
         messages: [{ role: "user", content: userContent }],
       }),
     });
+  } else if (apiFormat === "azure") {
+    const url = baseUrl.replace(/\/$/, "") + "/chat/completions?api-version=2024-12-01-preview";
+    resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": apiKey,
+      },
+      body: JSON.stringify({
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userContent },
+        ],
+        max_tokens: 2000,
+      }),
+    });
   } else {
     const url = baseUrl.replace(/\/$/, "") + "/chat/completions";
     resp = await fetch(url, {

--- a/markdown-sheet/src/types.ts
+++ b/markdown-sheet/src/types.ts
@@ -55,7 +55,7 @@ export interface AiSettings {
   apiKey: string;
   model: string;
   baseUrl: string;
-  apiFormat: "openai" | "anthropic";
+  apiFormat: "openai" | "anthropic" | "azure";
 }
 
 /** エディタタブ1つ分の保存状態 */


### PR DESCRIPTION
## Summary
- Azure OpenAI をプロバイダとして選択可能に追加
- Markdownプレビューで相対パスの画像を正しく解決するように修正
- Azure OpenAI API の `max_tokens` → `max_completion_tokens` パラメータ修正（GPT-4o以降の新モデル対応）

## Test plan
- [ ] 設定画面で Azure OpenAI を選択し、接続テストが成功することを確認
- [ ] Azure OpenAI 経由でAI機能（セル生成等）が正常に動作することを確認
- [ ] 相対パスの画像がMarkdownプレビューで表示されることを確認
- [ ] 既存プロバイダ（OpenAI, Anthropic等）が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)