### PR TITLE
Add DOCX export feature with font and mermaid support

### DIFF
--- a/markdown-sheet/package-lock.json
+++ b/markdown-sheet/package-lock.json
@@ -1,23 +1,31 @@
 {
   "name": "markdown-sheet",
-  "version": "0.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-sheet",
-      "version": "0.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@tauri-apps/api": "^2.2.0",
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-fs": "^2.2.0",
+        "docx": "^9.1.1",
         "highlight.js": "^11.11.1",
         "html2pdf.js": "^0.14.0",
         "katex": "^0.16.28",
         "marked": "^17.0.2",
+        "mathjax-full": "^3.2.2",
         "mermaid": "^11.12.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-math": "^6.0.0",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0",
+        "xml-js": "^1.6.11"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.2.0",
@@ -72,7 +80,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1808,6 +1815,15 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1820,6 +1836,45 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/pako": {
       "version": "2.0.4",
@@ -1840,7 +1895,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1861,6 +1915,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1883,6 +1943,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1893,6 +1962,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/base64-arraybuffer": {
@@ -1934,7 +2013,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1988,6 +2066,26 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chevrotain": {
@@ -2056,6 +2154,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cose-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
@@ -2086,7 +2190,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2487,7 +2590,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2592,7 +2694,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2606,6 +2707,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -2613,6 +2727,63 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/docx": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.0.tgz",
+      "integrity": "sha512-y6EaJJMDvt4P7wgGQB9KsZf4wsRkQMJfkc9LlNufRshggI5BT35hGNkXBCAeEoI3MLMwApKguxzjdqqVcBCqNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/dompurify": {
@@ -2683,6 +2854,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-png": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
@@ -2749,6 +2947,16 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -2794,6 +3002,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2807,6 +3027,24 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -2858,6 +3096,24 @@
         "dompurify": "^3.3.1",
         "html2canvas": "^1.0.0-rc.5"
       }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/katex": {
       "version": "0.16.28",
@@ -2911,11 +3167,30 @@
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lodash-es": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -2925,6 +3200,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/marked": {
@@ -2937,6 +3222,227 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "deprecated": "Version 4 replaces this package with the scoped package @mathjax/src",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mermaid": {
@@ -2979,6 +3485,606 @@
         "node": ">= 20"
       }
     },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -2995,7 +4101,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3068,7 +4173,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3132,6 +4236,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -3147,7 +4257,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3174,12 +4283,92 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/rgbcolor": {
       "version": "1.0.1",
@@ -3260,11 +4449,26 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -3282,6 +4486,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3292,6 +4502,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.2.tgz",
+      "integrity": "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.8",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -3300,6 +4533,15 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/stylis": {
@@ -3353,6 +4595,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -3381,6 +4633,100 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3413,6 +4759,12 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utrie": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
@@ -3435,13 +4787,40 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3560,12 +4939,46 @@
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
       "license": "MIT"
     },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "license": "MIT"
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/markdown-sheet/package.json
+++ b/markdown-sheet/package.json
@@ -13,13 +13,21 @@
     "@tauri-apps/api": "^2.2.0",
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.2.0",
+    "docx": "^9.1.1",
     "highlight.js": "^11.11.1",
     "html2pdf.js": "^0.14.0",
     "katex": "^0.16.28",
     "marked": "^17.0.2",
+    "mathjax-full": "^3.2.2",
     "mermaid": "^11.12.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-math": "^6.0.0",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0",
+    "xml-js": "^1.6.11"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.2.0",

--- a/markdown-sheet/public/themes/code-themes/business-contrast.json
+++ b/markdown-sheet/public/themes/code-themes/business-contrast.json
@@ -1,0 +1,31 @@
+{
+  "id": "business-contrast",
+  "name": "商务对比",
+  "description": "高对比度配色，适合演示和商务",
+  "description_en": "Business contrast colors for presentation",
+  
+  "foreground": "#000000",
+  "colors": {
+    "keyword": "#0000ff",
+    "built_in": "#0000ff",
+    "literal": "#a31515",
+    "number": "#a31515",
+    "string": "#a31515",
+    "title": "#a31515",
+    "attr": "#ff0000",
+    "comment": "#008000",
+    "meta": "#2b91af",
+    "params": "#000000",
+    "symbol": "#00b0e8",
+    "type": "#a31515",
+    "addition": "#a31515",
+    "deletion": "#2b91af",
+    "quote": "#008000",
+    "regexp": "#a31515",
+    "selector_tag": "#0000ff",
+    "selector_id": "#000000",
+    "selector_class": "#000000",
+    "variable": "#008000",
+    "property": "#000000"
+  }
+}

--- a/markdown-sheet/public/themes/code-themes/colorful.json
+++ b/markdown-sheet/public/themes/code-themes/colorful.json
@@ -1,0 +1,32 @@
+{
+  "id": "colorful",
+  "name": "多彩活力",
+  "description": "多彩配色方案，活力友好",
+  "description_en": "Colorful scheme, vibrant and friendly",
+  
+  "foreground": "#383a42",
+  "colors": {
+    "keyword": "#a626a4",
+    "built_in": "#c18401",
+    "literal": "#0184bb",
+    "number": "#986801",
+    "operator": "#383a42",
+    "string": "#50a14f",
+    "title": "#4078f2",
+    "attr": "#986801",
+    "comment": "#a0a1a7",
+    "meta": "#4078f2",
+    "params": "#383a42",
+    "symbol": "#e45649",
+    "type": "#c18401",
+    "addition": "#50a14f",
+    "deletion": "#e45649",
+    "quote": "#a0a1a7",
+    "regexp": "#50a14f",
+    "selector_tag": "#e45649",
+    "selector_id": "#4078f2",
+    "selector_class": "#c18401",
+    "variable": "#e45649",
+    "property": "#4078f2"
+  }
+}

--- a/markdown-sheet/public/themes/code-themes/cool-modern.json
+++ b/markdown-sheet/public/themes/code-themes/cool-modern.json
@@ -1,0 +1,31 @@
+{
+  "id": "cool-modern",
+  "name": "冷色现代",
+  "description": "现代冷色调配色，专业简洁",
+  "description_en": "Modern cool-toned colors, professional and clean",
+  
+  "foreground": "#263238",
+  "colors": {
+    "keyword": "#0277bd",
+    "built_in": "#00838f",
+    "literal": "#00897b",
+    "number": "#f57c00",
+    "string": "#00897b",
+    "title": "#1976d2",
+    "attr": "#00838f",
+    "comment": "#90a4ae",
+    "meta": "#5e35b1",
+    "params": "#263238",
+    "symbol": "#d32f2f",
+    "type": "#00838f",
+    "addition": "#388e3c",
+    "deletion": "#d32f2f",
+    "quote": "#90a4ae",
+    "regexp": "#00897b",
+    "selector_tag": "#0277bd",
+    "selector_id": "#1976d2",
+    "selector_class": "#00838f",
+    "variable": "#5e35b1",
+    "property": "#1976d2"
+  }
+}

--- a/markdown-sheet/public/themes/code-themes/high-contrast.json
+++ b/markdown-sheet/public/themes/code-themes/high-contrast.json
@@ -1,0 +1,31 @@
+{
+  "id": "business-contrast",
+  "name": "商务对比",
+  "description": "高对比度配色，适合演示和商务",
+  "description_en": "Business contrast colors for presentation",
+  
+  "foreground": "#000000",
+  "colors": {
+    "keyword": "#0000ff",
+    "built_in": "#0000ff",
+    "literal": "#a31515",
+    "number": "#a31515",
+    "string": "#a31515",
+    "title": "#a31515",
+    "attr": "#ff0000",
+    "comment": "#008000",
+    "meta": "#2b91af",
+    "params": "#000000",
+    "symbol": "#00b0e8",
+    "type": "#a31515",
+    "addition": "#a31515",
+    "deletion": "#2b91af",
+    "quote": "#008000",
+    "regexp": "#a31515",
+    "selector_tag": "#0000ff",
+    "selector_id": "#000000",
+    "selector_class": "#000000",
+    "variable": "#008000",
+    "property": "#000000"
+  }
+}

--- a/markdown-sheet/public/themes/code-themes/light-clean.json
+++ b/markdown-sheet/public/themes/code-themes/light-clean.json
@@ -1,0 +1,31 @@
+{
+  "id": "light-clean",
+  "name": "清爽亮色",
+  "description": "清爽的浅色配色方案，适合日常使用",
+  "description_en": "Clean light color scheme for daily use",
+  
+  "foreground": "#24292e",
+  "colors": {
+    "keyword": "#d73a49",
+    "built_in": "#e36209",
+    "literal": "#005cc5",
+    "number": "#005cc5",
+    "string": "#032f62",
+    "title": "#6f42c1",
+    "attr": "#005cc5",
+    "comment": "#6a737d",
+    "meta": "#005cc5",
+    "params": "#24292e",
+    "symbol": "#e36209",
+    "type": "#d73a49",
+    "addition": "#22863a",
+    "deletion": "#b31d28",
+    "quote": "#22863a",
+    "regexp": "#032f62",
+    "selector_tag": "#22863a",
+    "selector_id": "#005cc5",
+    "selector_class": "#005cc5",
+    "variable": "#e36209",
+    "property": "#005cc5"
+  }
+}

--- a/markdown-sheet/public/themes/code-themes/warm-book.json
+++ b/markdown-sheet/public/themes/code-themes/warm-book.json
@@ -1,0 +1,31 @@
+{
+  "id": "warm-book",
+  "name": "温暖书卷",
+  "description": "温暖的书籍风格配色，适合长文阅读",
+  "description_en": "Warm book-style colors for long reading",
+  
+  "foreground": "#657b83",
+  "colors": {
+    "keyword": "#859900",
+    "built_in": "#b58900",
+    "literal": "#2aa198",
+    "number": "#2aa198",
+    "string": "#2aa198",
+    "title": "#268bd2",
+    "attr": "#b58900",
+    "comment": "#93a1a1",
+    "meta": "#859900",
+    "params": "#657b83",
+    "symbol": "#cb4b16",
+    "type": "#b58900",
+    "addition": "#859900",
+    "deletion": "#dc322f",
+    "quote": "#93a1a1",
+    "regexp": "#dc322f",
+    "selector_tag": "#268bd2",
+    "selector_id": "#268bd2",
+    "selector_class": "#268bd2",
+    "variable": "#268bd2",
+    "property": "#268bd2"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/candy.json
+++ b/markdown-sheet/public/themes/color-schemes/candy.json
@@ -1,0 +1,34 @@
+{
+  "id": "candy",
+  "name": "糖果甜心",
+  "name_en": "Candy",
+  "description": "粉橙色系，甜美可爱的糖果风格",
+  "description_en": "Pink-orange scheme for sweet and adorable candy styles",
+  
+  "text": {
+    "primary": "#881337",
+    "secondary": "#9f1239",
+    "muted": "#be123c"
+  },
+  
+  "accent": {
+    "link": "#e11d48",
+    "linkHover": "#be123c"
+  },
+  
+  "background": {
+    "code": "#fff1f2"
+  },
+  
+  "blockquote": {
+    "border": "#fda4af"
+  },
+  
+  "table": {
+    "border": "#fda4af",
+    "headerBackground": "#fecdd3",
+    "headerText": "#881337",
+    "zebraEven": "#fff1f2",
+    "zebraOdd": "#fff7ed"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/cool.json
+++ b/markdown-sheet/public/themes/color-schemes/cool.json
@@ -1,0 +1,34 @@
+{
+  "id": "cool",
+  "name": "冷色调",
+  "name_en": "Cool",
+  "description": "清爽的蓝色系，适合技术和科技风格",
+  "description_en": "Cool blue scheme for technical and modern styles",
+  
+  "text": {
+    "primary": "#0f172a",
+    "secondary": "#334155",
+    "muted": "#64748b"
+  },
+  
+  "accent": {
+    "link": "#0077b6",
+    "linkHover": "#005f92"
+  },
+  
+  "background": {
+    "code": "#f0f9ff"
+  },
+  
+  "blockquote": {
+    "border": "#7dd3fc"
+  },
+  
+  "table": {
+    "border": "#7dd3fc",
+    "headerBackground": "#e0f2fe",
+    "headerText": "#0c4a6e",
+    "zebraEven": "#f0f9ff",
+    "zebraOdd": "#ffffff"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/coral.json
+++ b/markdown-sheet/public/themes/color-schemes/coral.json
@@ -1,0 +1,34 @@
+{
+  "id": "coral",
+  "name": "珊瑚活力",
+  "name_en": "Coral",
+  "description": "温暖橙粉色系，友好亲和的活力风格",
+  "description_en": "Warm coral-pink scheme for friendly and vibrant styles",
+  
+  "text": {
+    "primary": "#450a0a",
+    "secondary": "#7f1d1d",
+    "muted": "#b91c1c"
+  },
+  
+  "accent": {
+    "link": "#dc2626",
+    "linkHover": "#b91c1c"
+  },
+  
+  "background": {
+    "code": "#fef2f2"
+  },
+  
+  "blockquote": {
+    "border": "#fca5a5"
+  },
+  
+  "table": {
+    "border": "#fca5a5",
+    "headerBackground": "#fecaca",
+    "headerText": "#450a0a",
+    "zebraEven": "#fff5f5",
+    "zebraOdd": "#fffbeb"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/dino.json
+++ b/markdown-sheet/public/themes/color-schemes/dino.json
@@ -1,0 +1,34 @@
+{
+  "id": "dino",
+  "name": "恐龙探险",
+  "name_en": "Dinosaur",
+  "description": "绿橙色系，活力探索的恐龙风格",
+  "description_en": "Green-orange scheme for adventurous dinosaur styles",
+  
+  "text": {
+    "primary": "#365314",
+    "secondary": "#3f6212",
+    "muted": "#65a30d"
+  },
+  
+  "accent": {
+    "link": "#4d7c0f",
+    "linkHover": "#3f6212"
+  },
+  
+  "background": {
+    "code": "#f7fee7"
+  },
+  
+  "blockquote": {
+    "border": "#a3e635"
+  },
+  
+  "table": {
+    "border": "#a3e635",
+    "headerBackground": "#bef264",
+    "headerText": "#365314",
+    "zebraEven": "#f7fee7",
+    "zebraOdd": "#fff7ed"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/forest.json
+++ b/markdown-sheet/public/themes/color-schemes/forest.json
@@ -1,0 +1,34 @@
+{
+  "id": "forest",
+  "name": "森林自然",
+  "name_en": "Forest",
+  "description": "绿色系，自然环保的森林风格",
+  "description_en": "Green scheme for natural and eco-friendly forest styles",
+  
+  "text": {
+    "primary": "#14532d",
+    "secondary": "#166534",
+    "muted": "#4d7c0f"
+  },
+  
+  "accent": {
+    "link": "#15803d",
+    "linkHover": "#166534"
+  },
+  
+  "background": {
+    "code": "#f0fdf4"
+  },
+  
+  "blockquote": {
+    "border": "#4ade80"
+  },
+  
+  "table": {
+    "border": "#4ade80",
+    "headerBackground": "#bbf7d0",
+    "headerText": "#14532d",
+    "zebraEven": "#f0fdf4",
+    "zebraOdd": "#fefce8"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/garden.json
+++ b/markdown-sheet/public/themes/color-schemes/garden.json
@@ -1,0 +1,34 @@
+{
+  "id": "garden",
+  "name": "花园清新",
+  "name_en": "Garden",
+  "description": "粉绿色系，清新可爱的花园风格",
+  "description_en": "Pink-green scheme for fresh and lovely garden styles",
+  
+  "text": {
+    "primary": "#701a75",
+    "secondary": "#86198f",
+    "muted": "#a21caf"
+  },
+  
+  "accent": {
+    "link": "#047857",
+    "linkHover": "#065f46"
+  },
+  
+  "background": {
+    "code": "#fdf2f8"
+  },
+  
+  "blockquote": {
+    "border": "#4ade80"
+  },
+  
+  "table": {
+    "border": "#4ade80",
+    "headerBackground": "#dcfce7",
+    "headerText": "#166534",
+    "zebraEven": "#f0fdf4",
+    "zebraOdd": "#fefce8"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/neutral.json
+++ b/markdown-sheet/public/themes/color-schemes/neutral.json
@@ -1,0 +1,34 @@
+{
+  "id": "neutral",
+  "name": "中性色",
+  "name_en": "Neutral",
+  "description": "经典黑白灰配色，适合大多数文档",
+  "description_en": "Classic black/white/gray scheme for most documents",
+  
+  "text": {
+    "primary": "#171717",
+    "secondary": "#404040",
+    "muted": "#737373"
+  },
+  
+  "accent": {
+    "link": "#0369a1",
+    "linkHover": "#0c4a6e"
+  },
+  
+  "background": {
+    "code": "#f5f5f5"
+  },
+  
+  "blockquote": {
+    "border": "#a3a3a3"
+  },
+  
+  "table": {
+    "border": "#a3a3a3",
+    "headerBackground": "#e5e5e5",
+    "headerText": "#171717",
+    "zebraEven": "#fafafa",
+    "zebraOdd": "#ffffff"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/ocean.json
+++ b/markdown-sheet/public/themes/color-schemes/ocean.json
@@ -1,0 +1,34 @@
+{
+  "id": "ocean",
+  "name": "海洋清新",
+  "name_en": "Ocean",
+  "description": "蓝绿色系，清爽自然的海洋风格",
+  "description_en": "Blue-green scheme for fresh and natural ocean styles",
+  
+  "text": {
+    "primary": "#164e63",
+    "secondary": "#155e75",
+    "muted": "#0e7490"
+  },
+  
+  "accent": {
+    "link": "#0e7490",
+    "linkHover": "#155e75"
+  },
+  
+  "background": {
+    "code": "#ecfeff"
+  },
+  
+  "blockquote": {
+    "border": "#22d3ee"
+  },
+  
+  "table": {
+    "border": "#22d3ee",
+    "headerBackground": "#a5f3fc",
+    "headerText": "#164e63",
+    "zebraEven": "#ecfeff",
+    "zebraOdd": "#f0fdfa"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/rainbow.json
+++ b/markdown-sheet/public/themes/color-schemes/rainbow.json
@@ -1,0 +1,43 @@
+{
+  "id": "rainbow",
+  "name": "彩虹多彩",
+  "name_en": "Rainbow",
+  "description": "各级标题不同颜色，活泼童趣的多彩风格",
+  "description_en": "Multi-colored headings for vibrant and playful styles",
+  
+  "text": {
+    "primary": "#1e1b4b",
+    "secondary": "#3730a3",
+    "muted": "#6366f1"
+  },
+  
+  "accent": {
+    "link": "#7c3aed",
+    "linkHover": "#6d28d9"
+  },
+  
+  "background": {
+    "code": "#eef2ff"
+  },
+  
+  "blockquote": {
+    "border": "#a5b4fc"
+  },
+  
+  "table": {
+    "border": "#a5b4fc",
+    "headerBackground": "#e0e7ff",
+    "headerText": "#1e1b4b",
+    "zebraEven": "#faf5ff",
+    "zebraOdd": "#ffffff"
+  },
+  
+  "headings": {
+    "h1": "#ef4444",
+    "h2": "#f97316",
+    "h3": "#eab308",
+    "h4": "#22c55e",
+    "h5": "#3b82f6",
+    "h6": "#8b5cf6"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/sakura.json
+++ b/markdown-sheet/public/themes/color-schemes/sakura.json
@@ -1,0 +1,34 @@
+{
+  "id": "sakura",
+  "name": "樱花粉",
+  "name_en": "Sakura",
+  "description": "柔和的粉色系，适合温柔优雅的风格",
+  "description_en": "Soft pink scheme for gentle and elegant styles",
+  
+  "text": {
+    "primary": "#831843",
+    "secondary": "#9d174d",
+    "muted": "#be185d"
+  },
+  
+  "accent": {
+    "link": "#db2777",
+    "linkHover": "#be185d"
+  },
+  
+  "background": {
+    "code": "#fdf2f8"
+  },
+  
+  "blockquote": {
+    "border": "#f9a8d4"
+  },
+  
+  "table": {
+    "border": "#f9a8d4",
+    "headerBackground": "#fce7f3",
+    "headerText": "#831843",
+    "zebraEven": "#fdf2f8",
+    "zebraOdd": "#fffbfc"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/sepia.json
+++ b/markdown-sheet/public/themes/color-schemes/sepia.json
@@ -1,0 +1,34 @@
+{
+  "id": "sepia",
+  "name": "复古棕",
+  "name_en": "Sepia",
+  "description": "怀旧的泛黄色调，适合打字机和手稿风格",
+  "description_en": "Nostalgic sepia tones for typewriter and manuscript styles",
+  
+  "text": {
+    "primary": "#292524",
+    "secondary": "#57534e",
+    "muted": "#78716c"
+  },
+  
+  "accent": {
+    "link": "#a16207",
+    "linkHover": "#854d0e"
+  },
+  
+  "background": {
+    "code": "#faf5ef"
+  },
+  
+  "blockquote": {
+    "border": "#a8a29e"
+  },
+  
+  "table": {
+    "border": "#a8a29e",
+    "headerBackground": "#f5f0e6",
+    "headerText": "#292524",
+    "zebraEven": "#faf5ef",
+    "zebraOdd": "#fcf9f3"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/space.json
+++ b/markdown-sheet/public/themes/color-schemes/space.json
@@ -1,0 +1,34 @@
+{
+  "id": "space",
+  "name": "太空探索",
+  "name_en": "Space",
+  "description": "蓝橙色系，科幻好奇的太空风格",
+  "description_en": "Blue-orange scheme for sci-fi space exploration styles",
+  
+  "text": {
+    "primary": "#1e3a8a",
+    "secondary": "#1e40af",
+    "muted": "#3b82f6"
+  },
+  
+  "accent": {
+    "link": "#4f46e5",
+    "linkHover": "#4338ca"
+  },
+  
+  "background": {
+    "code": "#eff6ff"
+  },
+  
+  "blockquote": {
+    "border": "#93c5fd"
+  },
+  
+  "table": {
+    "border": "#93c5fd",
+    "headerBackground": "#bfdbfe",
+    "headerText": "#1e3a8a",
+    "zebraEven": "#eff6ff",
+    "zebraOdd": "#fff7ed"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/starry.json
+++ b/markdown-sheet/public/themes/color-schemes/starry.json
@@ -1,0 +1,34 @@
+{
+  "id": "starry",
+  "name": "星空梦幻",
+  "name_en": "Starry",
+  "description": "蓝紫色系，梦幻童趣的星空风格",
+  "description_en": "Blue-purple scheme for dreamy starry styles",
+  
+  "text": {
+    "primary": "#4c1d95",
+    "secondary": "#5b21b6",
+    "muted": "#7c3aed"
+  },
+  
+  "accent": {
+    "link": "#a21caf",
+    "linkHover": "#86198f"
+  },
+  
+  "background": {
+    "code": "#eef2ff"
+  },
+  
+  "blockquote": {
+    "border": "#a5b4fc"
+  },
+  
+  "table": {
+    "border": "#a5b4fc",
+    "headerBackground": "#c7d2fe",
+    "headerText": "#1e1b4b",
+    "zebraEven": "#f5f3ff",
+    "zebraOdd": "#faf5ff"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/sunset.json
+++ b/markdown-sheet/public/themes/color-schemes/sunset.json
@@ -1,0 +1,34 @@
+{
+  "id": "sunset",
+  "name": "日落暖阳",
+  "name_en": "Sunset",
+  "description": "橙黄色系，温暖舒适的日落风格",
+  "description_en": "Orange-yellow scheme for warm and cozy sunset styles",
+  
+  "text": {
+    "primary": "#431407",
+    "secondary": "#7c2d12",
+    "muted": "#c2410c"
+  },
+  
+  "accent": {
+    "link": "#c2410c",
+    "linkHover": "#9a3412"
+  },
+  
+  "background": {
+    "code": "#fff7ed"
+  },
+  
+  "blockquote": {
+    "border": "#fdba74"
+  },
+  
+  "table": {
+    "border": "#fdba74",
+    "headerBackground": "#fed7aa",
+    "headerText": "#431407",
+    "zebraEven": "#fff7ed",
+    "zebraOdd": "#fffbeb"
+  }
+}

--- a/markdown-sheet/public/themes/color-schemes/warm.json
+++ b/markdown-sheet/public/themes/color-schemes/warm.json
@@ -1,0 +1,34 @@
+{
+  "id": "warm",
+  "name": "暖色调",
+  "name_en": "Warm",
+  "description": "温暖的棕橙色系，适合文艺和手写风格",
+  "description_en": "Warm brown-orange scheme for literary and handwritten styles",
+  
+  "text": {
+    "primary": "#1c1917",
+    "secondary": "#44403c",
+    "muted": "#78716c"
+  },
+  
+  "accent": {
+    "link": "#b45309",
+    "linkHover": "#92400e"
+  },
+  
+  "background": {
+    "code": "#faf5f0"
+  },
+  
+  "blockquote": {
+    "border": "#a8a29e"
+  },
+  
+  "table": {
+    "border": "#a8a29e",
+    "headerBackground": "#fef3e2",
+    "headerText": "#1c1917",
+    "zebraEven": "#fffbf5",
+    "zebraOdd": "#fffcf7"
+  }
+}

--- a/markdown-sheet/public/themes/font-config.json
+++ b/markdown-sheet/public/themes/font-config.json
@@ -1,0 +1,184 @@
+{
+  "fonts": {
+    "Times New Roman": {
+      "name": "Times New Roman",
+      "displayName": "Times New Roman",
+      "webFallback": "'Times New Roman', Times, Georgia, serif, SimSun, STSong",
+      "docx": {
+        "ascii": "Times New Roman",
+        "eastAsia": "SimSun"
+      }
+    },
+    "Arial": {
+      "name": "Arial",
+      "displayName": "Arial",
+      "webFallback": "Arial, Helvetica, 'Helvetica Neue', sans-serif, SimHei, STHeiti",
+      "docx": {
+        "ascii": "Arial",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Georgia": {
+      "name": "Georgia",
+      "displayName": "Georgia",
+      "webFallback": "Georgia, 'Times New Roman', Times, serif, SimSun, STSong",
+      "docx": {
+        "ascii": "Georgia",
+        "eastAsia": "SimSun"
+      }
+    },
+    "Monaco": {
+      "name": "Monaco",
+      "displayName": "Monaco",
+      "webFallback": "Monaco, 'Courier New', monospace, FangSong, STFangsong, 'Zhuque Fangsong'",
+      "docx": {
+        "ascii": "Consolas",
+        "eastAsia": "FangSong"
+      }
+    },
+    "Courier New": {
+      "name": "Courier New",
+      "displayName": "Courier New",
+      "webFallback": "'Courier New', Courier, Monaco, FangSong, STFangsong, 'Zhuque Fangsong', monospace",
+      "docx": {
+        "ascii": "Courier New",
+        "eastAsia": "FangSong"
+      }
+    },
+    "SimSun": {
+      "name": "SimSun",
+      "displayName": "宋体 (SimSun)",
+      "webFallback": "'Times New Roman', serif, SimSun, STSong",
+      "docx": {
+        "ascii": "Times New Roman",
+        "eastAsia": "SimSun"
+      }
+    },
+    "SimHei": {
+      "name": "SimHei",
+      "displayName": "黑体 (SimHei)",
+      "webFallback": "Arial, sans-serif, SimHei, STHeiti",
+      "docx": {
+        "ascii": "Arial",
+        "eastAsia": "SimHei"
+      }
+    },
+    "FangSong": {
+      "name": "FangSong",
+      "displayName": "仿宋 (FangSong)",
+      "webFallback": "FangSong, STFangsong, 'Zhuque Fangsong', Georgia, 'Times New Roman', serif",
+      "docx": {
+        "ascii": "Georgia",
+        "eastAsia": "FangSong"
+      }
+    },
+    "Palatino": {
+      "name": "Palatino",
+      "displayName": "Palatino",
+      "webFallback": "Palatino, Georgia, 'Times New Roman', serif, STSong, SimSun",
+      "docx": {
+        "ascii": "Palatino Linotype",
+        "eastAsia": "SimSun"
+      }
+    },
+    "Verdana": {
+      "name": "Verdana",
+      "displayName": "Verdana",
+      "webFallback": "Verdana, Geneva, Tahoma, Arial, sans-serif, SimHei",
+      "docx": {
+        "ascii": "Verdana",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Tahoma": {
+      "name": "Tahoma",
+      "displayName": "Tahoma",
+      "webFallback": "Tahoma, Verdana, Arial, sans-serif, SimHei",
+      "docx": {
+        "ascii": "Tahoma",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Trebuchet MS": {
+      "name": "Trebuchet MS",
+      "displayName": "Trebuchet MS",
+      "webFallback": "'Trebuchet MS', Tahoma, Arial, sans-serif, SimHei",
+      "docx": {
+        "ascii": "Trebuchet MS",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Comic Sans MS": {
+      "name": "Comic Sans MS",
+      "displayName": "Comic Sans MS",
+      "webFallback": "'Comic Sans MS', 'Comic Neue', 'Marker Felt', FangSong, STFangsong, 'Zhuque Fangsong'",
+      "docx": {
+        "ascii": "Comic Sans MS",
+        "eastAsia": "FangSong"
+      }
+    },
+    "Impact": {
+      "name": "Impact",
+      "displayName": "Impact",
+      "webFallback": "Impact, 'Arial Black', Arial, sans-serif, SimHei",
+      "docx": {
+        "ascii": "Impact",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Lucida Grande": {
+      "name": "Lucida Grande",
+      "displayName": "Lucida Grande",
+      "webFallback": "'Lucida Grande', Geneva, Verdana, Arial, sans-serif, STHeiti, SimHei",
+      "docx": {
+        "ascii": "Lucida Sans Unicode",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Palatino Linotype": {
+      "name": "Palatino Linotype",
+      "displayName": "Palatino Linotype",
+      "webFallback": "'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, 'Times New Roman', serif, SimSun, STSong",
+      "docx": {
+        "ascii": "Palatino Linotype",
+        "eastAsia": "SimSun"
+      }
+    },
+    "Consolas": {
+      "name": "Consolas",
+      "displayName": "Consolas",
+      "webFallback": "Consolas, Monaco, 'Courier New', monospace, FangSong, STFangsong, 'Zhuque Fangsong'",
+      "docx": {
+        "ascii": "Consolas",
+        "eastAsia": "FangSong"
+      }
+    },
+    "Garamond": {
+      "name": "Garamond",
+      "displayName": "Garamond",
+      "webFallback": "Garamond, 'Times New Roman', Georgia, serif, SimSun, STSong",
+      "docx": {
+        "ascii": "Garamond",
+        "eastAsia": "SimSun"
+      }
+    },
+    "Helvetica Neue": {
+      "name": "Helvetica Neue",
+      "displayName": "Helvetica Neue",
+      "webFallback": "'Helvetica Neue', Helvetica, Arial, sans-serif, SimHei, STHeiti",
+      "docx": {
+        "ascii": "Arial",
+        "eastAsia": "SimHei"
+      }
+    },
+    "Century Gothic": {
+      "name": "Century Gothic",
+      "displayName": "Century Gothic",
+      "webFallback": "'Century Gothic', 'Apple Gothic', Arial, sans-serif, SimHei, STHeiti",
+      "docx": {
+        "ascii": "Century Gothic",
+        "eastAsia": "SimHei"
+      }
+    }
+  }
+}

--- a/markdown-sheet/public/themes/layout-schemes/academic.json
+++ b/markdown-sheet/public/themes/layout-schemes/academic.json
@@ -1,0 +1,40 @@
+{
+  "id": "academic",
+  "name": "学术论文",
+  "name_en": "Academic",
+  "description": "层级平缓的布局，适合学术论文和正式文档",
+  "description_en": "Gradual hierarchy layout for academic papers and formal documents",
+  
+  "body": {
+    "fontSize": "12pt",
+    "lineHeight": 1.75
+  },
+  
+  "headings": {
+    "h1": { "fontSize": "18pt", "spacingBefore": "0pt", "spacingAfter": "16pt" },
+    "h2": { "fontSize": "16pt", "spacingBefore": "16pt", "spacingAfter": "10pt" },
+    "h3": { "fontSize": "14pt", "spacingBefore": "14pt", "spacingAfter": "8pt" },
+    "h4": { "fontSize": "13pt", "spacingBefore": "12pt", "spacingAfter": "6pt" },
+    "h5": { "fontSize": "12pt", "spacingBefore": "10pt", "spacingAfter": "5pt" },
+    "h6": { "fontSize": "12pt", "spacingBefore": "8pt", "spacingAfter": "4pt" }
+  },
+  
+  "code": {
+    "fontSize": "10pt"
+  },
+  
+  "blocks": {
+    "paragraph": { "spacingAfter": "10pt" },
+    "list": { "spacingAfter": "13pt" },
+    "listItem": { "spacingAfter": "3pt" },
+    "blockquote": { 
+      "spacingBefore": "10pt",
+      "spacingAfter": "10pt",
+      "paddingVertical": "1pt",
+      "paddingHorizontal": "13pt"
+    },
+    "codeBlock": { "spacingAfter": "12pt" },
+    "table": { "spacingAfter": "12pt" },
+    "horizontalRule": { "spacingBefore": "20pt", "spacingAfter": "20pt" }
+  }
+}

--- a/markdown-sheet/public/themes/layout-schemes/book.json
+++ b/markdown-sheet/public/themes/layout-schemes/book.json
@@ -1,0 +1,40 @@
+{
+  "id": "book",
+  "name": "书籍排版",
+  "name_en": "Book",
+  "description": "舒适阅读的布局，适合长文档和书籍",
+  "description_en": "Comfortable reading layout for long documents and books",
+  
+  "body": {
+    "fontSize": "12pt",
+    "lineHeight": 1.6
+  },
+  
+  "headings": {
+    "h1": { "fontSize": "22pt", "spacingBefore": "0pt", "spacingAfter": "14pt" },
+    "h2": { "fontSize": "18pt", "spacingBefore": "18pt", "spacingAfter": "10pt" },
+    "h3": { "fontSize": "16pt", "spacingBefore": "16pt", "spacingAfter": "8pt" },
+    "h4": { "fontSize": "14pt", "spacingBefore": "14pt", "spacingAfter": "7pt" },
+    "h5": { "fontSize": "13pt", "spacingBefore": "12pt", "spacingAfter": "6pt" },
+    "h6": { "fontSize": "12pt", "spacingBefore": "10pt", "spacingAfter": "5pt" }
+  },
+  
+  "code": {
+    "fontSize": "10pt"
+  },
+  
+  "blocks": {
+    "paragraph": { "spacingAfter": "12pt" },
+    "list": { "spacingAfter": "14pt" },
+    "listItem": { "spacingAfter": "4pt" },
+    "blockquote": { 
+      "spacingBefore": "12pt",
+      "spacingAfter": "12pt",
+      "paddingVertical": "2pt",
+      "paddingHorizontal": "15pt"
+    },
+    "codeBlock": { "spacingAfter": "14pt" },
+    "table": { "spacingAfter": "14pt" },
+    "horizontalRule": { "spacingBefore": "24pt", "spacingAfter": "24pt" }
+  }
+}

--- a/markdown-sheet/public/themes/layout-schemes/document.json
+++ b/markdown-sheet/public/themes/layout-schemes/document.json
@@ -1,0 +1,40 @@
+{
+  "id": "document",
+  "name": "通用文档",
+  "name_en": "Document",
+  "description": "平衡适中的布局，适合日常文档",
+  "description_en": "Balanced layout for everyday documents",
+  
+  "body": {
+    "fontSize": "12pt",
+    "lineHeight": 1.5
+  },
+  
+  "headings": {
+    "h1": { "fontSize": "22pt", "spacingBefore": "0pt", "spacingAfter": "12pt", "alignment": "center" },
+    "h2": { "fontSize": "18pt", "spacingBefore": "16pt", "spacingAfter": "8pt" },
+    "h3": { "fontSize": "16pt", "spacingBefore": "14pt", "spacingAfter": "7pt" },
+    "h4": { "fontSize": "14pt", "spacingBefore": "12pt", "spacingAfter": "6pt" },
+    "h5": { "fontSize": "13pt", "spacingBefore": "10pt", "spacingAfter": "5pt" },
+    "h6": { "fontSize": "12pt", "spacingBefore": "8pt", "spacingAfter": "4pt" }
+  },
+  
+  "code": {
+    "fontSize": "10pt"
+  },
+  
+  "blocks": {
+    "paragraph": { "spacingAfter": "10pt" },
+    "list": { "spacingAfter": "13pt" },
+    "listItem": { "spacingAfter": "3pt" },
+    "blockquote": { 
+      "spacingBefore": "10pt",
+      "spacingAfter": "10pt",
+      "paddingVertical": "1pt",
+      "paddingHorizontal": "13pt"
+    },
+    "codeBlock": { "spacingAfter": "12pt" },
+    "table": { "spacingAfter": "12pt" },
+    "horizontalRule": { "spacingBefore": "20pt", "spacingAfter": "20pt" }
+  }
+}

--- a/markdown-sheet/public/themes/layout-schemes/magazine.json
+++ b/markdown-sheet/public/themes/layout-schemes/magazine.json
@@ -1,0 +1,40 @@
+{
+  "id": "magazine",
+  "name": "杂志风格",
+  "name_en": "Magazine",
+  "description": "大标题差异的布局，适合杂志和创意文档",
+  "description_en": "Large heading contrast layout for magazines and creative documents",
+  
+  "body": {
+    "fontSize": "12pt",
+    "lineHeight": 1.5
+  },
+  
+  "headings": {
+    "h1": { "fontSize": "28pt", "spacingBefore": "0pt", "spacingAfter": "16pt" },
+    "h2": { "fontSize": "22pt", "spacingBefore": "20pt", "spacingAfter": "10pt" },
+    "h3": { "fontSize": "18pt", "spacingBefore": "16pt", "spacingAfter": "8pt" },
+    "h4": { "fontSize": "15pt", "spacingBefore": "14pt", "spacingAfter": "7pt" },
+    "h5": { "fontSize": "13pt", "spacingBefore": "12pt", "spacingAfter": "6pt" },
+    "h6": { "fontSize": "12pt", "spacingBefore": "10pt", "spacingAfter": "5pt" }
+  },
+  
+  "code": {
+    "fontSize": "10pt"
+  },
+  
+  "blocks": {
+    "paragraph": { "spacingAfter": "10pt" },
+    "list": { "spacingAfter": "13pt" },
+    "listItem": { "spacingAfter": "3pt" },
+    "blockquote": { 
+      "spacingBefore": "12pt",
+      "spacingAfter": "12pt",
+      "paddingVertical": "2pt",
+      "paddingHorizontal": "16pt"
+    },
+    "codeBlock": { "spacingAfter": "12pt" },
+    "table": { "spacingAfter": "12pt" },
+    "horizontalRule": { "spacingBefore": "20pt", "spacingAfter": "20pt" }
+  }
+}

--- a/markdown-sheet/public/themes/layout-schemes/student.json
+++ b/markdown-sheet/public/themes/layout-schemes/student.json
@@ -1,0 +1,40 @@
+{
+  "id": "student",
+  "name": "学生文档",
+  "name_en": "Student",
+  "description": "大字号大行距，适合学生作文和笔记",
+  "description_en": "Large font and spacing for student essays and notes",
+  
+  "body": {
+    "fontSize": "14pt",
+    "lineHeight": 1.8
+  },
+  
+  "headings": {
+    "h1": { "fontSize": "24pt", "spacingBefore": "0pt", "spacingAfter": "16pt" },
+    "h2": { "fontSize": "20pt", "spacingBefore": "20pt", "spacingAfter": "12pt" },
+    "h3": { "fontSize": "18pt", "spacingBefore": "18pt", "spacingAfter": "10pt" },
+    "h4": { "fontSize": "16pt", "spacingBefore": "16pt", "spacingAfter": "8pt" },
+    "h5": { "fontSize": "15pt", "spacingBefore": "14pt", "spacingAfter": "7pt" },
+    "h6": { "fontSize": "14pt", "spacingBefore": "12pt", "spacingAfter": "6pt" }
+  },
+  
+  "code": {
+    "fontSize": "12pt"
+  },
+  
+  "blocks": {
+    "paragraph": { "spacingAfter": "14pt" },
+    "list": { "spacingAfter": "16pt" },
+    "listItem": { "spacingAfter": "6pt" },
+    "blockquote": { 
+      "spacingBefore": "14pt",
+      "spacingAfter": "14pt",
+      "paddingVertical": "4pt",
+      "paddingHorizontal": "18pt"
+    },
+    "codeBlock": { "spacingAfter": "16pt" },
+    "table": { "spacingAfter": "16pt" },
+    "horizontalRule": { "spacingBefore": "28pt", "spacingAfter": "28pt" }
+  }
+}

--- a/markdown-sheet/public/themes/layout-schemes/technical.json
+++ b/markdown-sheet/public/themes/layout-schemes/technical.json
@@ -1,0 +1,40 @@
+{
+  "id": "technical",
+  "name": "技术文档",
+  "name_en": "Technical",
+  "description": "紧凑高效的布局，适合技术文档和API文档",
+  "description_en": "Compact and efficient layout for technical and API documentation",
+  
+  "body": {
+    "fontSize": "11pt",
+    "lineHeight": 1.4
+  },
+  
+  "headings": {
+    "h1": { "fontSize": "18pt", "spacingBefore": "0pt", "spacingAfter": "10pt" },
+    "h2": { "fontSize": "15pt", "spacingBefore": "14pt", "spacingAfter": "7pt" },
+    "h3": { "fontSize": "13pt", "spacingBefore": "12pt", "spacingAfter": "6pt" },
+    "h4": { "fontSize": "12pt", "spacingBefore": "10pt", "spacingAfter": "5pt" },
+    "h5": { "fontSize": "11pt", "spacingBefore": "8pt", "spacingAfter": "4pt" },
+    "h6": { "fontSize": "11pt", "spacingBefore": "6pt", "spacingAfter": "3pt" }
+  },
+  
+  "code": {
+    "fontSize": "10pt"
+  },
+  
+  "blocks": {
+    "paragraph": { "spacingAfter": "8pt" },
+    "list": { "spacingAfter": "10pt" },
+    "listItem": { "spacingAfter": "2pt" },
+    "blockquote": { 
+      "spacingBefore": "8pt",
+      "spacingAfter": "8pt",
+      "paddingVertical": "1pt",
+      "paddingHorizontal": "12pt"
+    },
+    "codeBlock": { "spacingAfter": "10pt" },
+    "table": { "spacingAfter": "10pt" },
+    "horizontalRule": { "spacingBefore": "16pt", "spacingAfter": "16pt" }
+  }
+}

--- a/markdown-sheet/public/themes/presets/academic.json
+++ b/markdown-sheet/public/themes/presets/academic.json
@@ -1,0 +1,24 @@
+{
+  "id": "academic",
+  "name": "学术论文",
+  "name_en": "Academic",
+  "description": "宋体正文配黑体标题，中文学术规范",
+  "description_en": "Song body with Hei headings, Chinese academic standard",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "SimSun"
+    },
+    "headings": {
+      "fontFamily": "SimHei"
+    },
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "academic",
+  "colorScheme": "neutral",
+  "tableStyle": "academic",
+  "codeTheme": "light-clean"
+}

--- a/markdown-sheet/public/themes/presets/business.json
+++ b/markdown-sheet/public/themes/presets/business.json
@@ -1,0 +1,22 @@
+{
+  "id": "business",
+  "name": "商务报告",
+  "name_en": "Business",
+  "description": "Calibri 字体，现代商务风格，层次清晰",
+  "description_en": "Calibri font with modern business style and clear hierarchy",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Arial"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "neutral",
+  "tableStyle": "professional",
+  "codeTheme": "business-contrast"
+}

--- a/markdown-sheet/public/themes/presets/candy.json
+++ b/markdown-sheet/public/themes/presets/candy.json
@@ -1,0 +1,23 @@
+{
+  "id": "candy",
+  "name": "糖果甜心",
+  "name_en": "Candy",
+  "description": "糖果甜心，甜美可爱风格",
+  "description_en": "Sweet and adorable candy style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Trebuchet MS"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "student",
+  "colorScheme": "candy",
+  "tableStyle": "zebra",
+  "codeTheme": "colorful",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/century.json
+++ b/markdown-sheet/public/themes/presets/century.json
@@ -1,0 +1,22 @@
+{
+  "id": "century",
+  "name": "演示文稿",
+  "name_en": "Presentation",
+  "description": "Trebuchet MS 字体，简洁的演示风格，标题突出",
+  "description_en": "Trebuchet MS font with clean presentation style, prominent headings",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Century Gothic"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "magazine",
+  "colorScheme": "cool",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "cool-modern"
+}

--- a/markdown-sheet/public/themes/presets/coral.json
+++ b/markdown-sheet/public/themes/presets/coral.json
@@ -1,0 +1,22 @@
+{
+  "id": "coral",
+  "name": "珊瑚活力",
+  "name_en": "Coral Vibrant",
+  "description": "温暖橙粉色系，友好亲和的活力风格",
+  "description_en": "Warm coral-pink for friendly and vibrant style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Verdana"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "coral",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "colorful"
+}

--- a/markdown-sheet/public/themes/presets/default.json
+++ b/markdown-sheet/public/themes/presets/default.json
@@ -1,0 +1,22 @@
+{
+  "id": "default",
+  "name": "标准文档",
+  "name_en": "Standard",
+  "description": "Times New Roman 字体，适合正式文档和论文",
+  "description_en": "Times New Roman font for formal documents and papers",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Times New Roman"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "neutral",
+  "tableStyle": "grid",
+  "codeTheme": "light-clean"
+}

--- a/markdown-sheet/public/themes/presets/dinosaur.json
+++ b/markdown-sheet/public/themes/presets/dinosaur.json
@@ -1,0 +1,23 @@
+{
+  "id": "dinosaur",
+  "name": "恐龙探险",
+  "name_en": "Dinosaur",
+  "description": "绿橙探险，活力恐龙风格",
+  "description_en": "Green-orange adventurous dinosaur style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Arial"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "student",
+  "colorScheme": "dino",
+  "tableStyle": "grid",
+  "codeTheme": "colorful",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/elegant.json
+++ b/markdown-sheet/public/themes/presets/elegant.json
@@ -1,0 +1,22 @@
+{
+  "id": "elegant",
+  "name": "优雅文艺",
+  "name_en": "Elegant Literary",
+  "description": "Georgia 字体，优雅的文学风格",
+  "description_en": "Georgia font with elegant literary style",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Georgia"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "sakura",
+  "tableStyle": "borderless",
+  "codeTheme": "colorful"
+}

--- a/markdown-sheet/public/themes/presets/forest.json
+++ b/markdown-sheet/public/themes/presets/forest.json
@@ -1,0 +1,22 @@
+{
+  "id": "forest",
+  "name": "森林自然",
+  "name_en": "Forest Natural",
+  "description": "绿色系，自然环保的森林风格",
+  "description_en": "Green for natural and eco-friendly forest style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Verdana"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "forest",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "light-clean"
+}

--- a/markdown-sheet/public/themes/presets/garamond.json
+++ b/markdown-sheet/public/themes/presets/garamond.json
@@ -1,0 +1,22 @@
+{
+  "id": "garamond",
+  "name": "长文阅读",
+  "name_en": "Long Reading",
+  "description": "Georgia 字体，舒适的长文阅读体验",
+  "description_en": "Georgia font for comfortable long-form reading",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Garamond"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "warm",
+  "tableStyle": "borderless",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/presets/garden.json
+++ b/markdown-sheet/public/themes/presets/garden.json
@@ -1,0 +1,23 @@
+{
+  "id": "garden",
+  "name": "花园清新",
+  "name_en": "Garden",
+  "description": "粉绿清新，可爱花园风格",
+  "description_en": "Pink-green fresh garden style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Verdana"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "student",
+  "colorScheme": "garden",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "light-clean",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/handwritten.json
+++ b/markdown-sheet/public/themes/presets/handwritten.json
@@ -1,0 +1,23 @@
+{
+  "id": "handwritten",
+  "name": "手写风格",
+  "name_en": "Handwritten",
+  "description": "手写体标题，个人化感觉，适合日记和随笔",
+  "description_en": "Handwriting style titles for personal notes and journals",
+  "author": "Markdown Viewer Extension",
+  "version": "2.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Comic Sans MS"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "warm",
+  "tableStyle": "borderless",
+  "codeTheme": "warm-book",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/heiti.json
+++ b/markdown-sheet/public/themes/presets/heiti.json
@@ -1,0 +1,22 @@
+{
+  "id": "heiti",
+  "name": "现代黑体",
+  "name_en": "Hei Style",
+  "description": "黑体字体，现代简约风格",
+  "description_en": "Hei font with modern minimal style",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "SimHei"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "neutral",
+  "tableStyle": "grid",
+  "codeTheme": "light-clean"
+}

--- a/markdown-sheet/public/themes/presets/magazine.json
+++ b/markdown-sheet/public/themes/presets/magazine.json
@@ -1,0 +1,24 @@
+{
+  "id": "magazine",
+  "name": "杂志排版",
+  "name_en": "Magazine",
+  "description": "大标题差异，视觉冲击，适合创意内容展示",
+  "description_en": "Large title contrast with visual impact for creative content",
+  "author": "Markdown Viewer Extension",
+  "version": "2.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Georgia"
+    },
+    "headings": {
+      "fontFamily": "Helvetica Neue"
+    },
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "magazine",
+  "colorScheme": "cool",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "cool-modern"
+}

--- a/markdown-sheet/public/themes/presets/manuscript.json
+++ b/markdown-sheet/public/themes/presets/manuscript.json
@@ -1,0 +1,22 @@
+{
+  "id": "manuscript",
+  "name": "手稿风格",
+  "name_en": "Manuscript",
+  "description": "学术手稿感，适合论文草稿和研究笔记",
+  "description_en": "Academic manuscript style for paper drafts and research notes",
+  "author": "Markdown Viewer Extension",
+  "version": "2.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Palatino Linotype"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "academic",
+  "colorScheme": "sepia",
+  "tableStyle": "borderless",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/presets/minimal.json
+++ b/markdown-sheet/public/themes/presets/minimal.json
@@ -1,0 +1,22 @@
+{
+  "id": "minimal",
+  "name": "极简主义",
+  "name_en": "Minimal",
+  "description": "系统字体，最简洁的排版风格，专注内容本身",
+  "description_en": "System font with minimal styling, focus on content itself",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Arial"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "neutral",
+  "tableStyle": "borderless",
+  "codeTheme": "light-clean"
+}

--- a/markdown-sheet/public/themes/presets/mixed.json
+++ b/markdown-sheet/public/themes/presets/mixed.json
@@ -1,0 +1,24 @@
+{
+  "id": "mixed",
+  "name": "中英混排",
+  "name_en": "Mixed Languages",
+  "description": "宋体正文配 Georgia 标题，中英文混排优化",
+  "description_en": "Song body with Georgia headings for mixed content",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "SimSun"
+    },
+    "headings": {
+      "fontFamily": "Georgia"
+    },
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "warm",
+  "tableStyle": "grid",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/presets/newspaper.json
+++ b/markdown-sheet/public/themes/presets/newspaper.json
@@ -1,0 +1,24 @@
+{
+  "id": "newspaper",
+  "name": "报纸风格",
+  "name_en": "Newspaper",
+  "description": "传统新闻排版风格，正式严肃",
+  "description_en": "Traditional newspaper typography, formal and serious",
+  "author": "Markdown Viewer Extension",
+  "version": "2.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Times New Roman"
+    },
+    "headings": {
+      "fontFamily": "Georgia"
+    },
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "magazine",
+  "colorScheme": "sepia",
+  "tableStyle": "grid",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/presets/ocean.json
+++ b/markdown-sheet/public/themes/presets/ocean.json
@@ -1,0 +1,22 @@
+{
+  "id": "ocean",
+  "name": "海洋清新",
+  "name_en": "Ocean Fresh",
+  "description": "蓝绿色系，清爽自然的海洋风格",
+  "description_en": "Blue-green for fresh and natural ocean style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Trebuchet MS"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "ocean",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "cool-modern"
+}

--- a/markdown-sheet/public/themes/presets/palatino.json
+++ b/markdown-sheet/public/themes/presets/palatino.json
@@ -1,0 +1,22 @@
+{
+  "id": "palatino",
+  "name": "书籍出版",
+  "name_en": "Book Publishing",
+  "description": "Palatino 字体，优雅的书籍出版风格",
+  "description_en": "Palatino font with elegant book publishing style",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Palatino"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "sepia",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/presets/rainbow.json
+++ b/markdown-sheet/public/themes/presets/rainbow.json
@@ -1,0 +1,23 @@
+{
+  "id": "rainbow",
+  "name": "彩虹缤纷",
+  "name_en": "Rainbow",
+  "description": "多彩标题，活泼童趣的彩虹风格",
+  "description_en": "Multi-colored headings for vibrant rainbow style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Arial"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "student",
+  "colorScheme": "rainbow",
+  "tableStyle": "zebra",
+  "codeTheme": "colorful",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/space.json
+++ b/markdown-sheet/public/themes/presets/space.json
@@ -1,0 +1,23 @@
+{
+  "id": "space",
+  "name": "太空探索",
+  "name_en": "Space",
+  "description": "蓝橙科幻，太空探索风格",
+  "description_en": "Blue-orange sci-fi space exploration style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Arial"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "student",
+  "colorScheme": "space",
+  "tableStyle": "modern-tech",
+  "codeTheme": "cool-modern",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/starry.json
+++ b/markdown-sheet/public/themes/presets/starry.json
@@ -1,0 +1,23 @@
+{
+  "id": "starry",
+  "name": "星空梦幻",
+  "name_en": "Starry",
+  "description": "蓝紫梦幻，童趣星空风格",
+  "description_en": "Blue-purple dreamy starry style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Century Gothic"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "student",
+  "colorScheme": "starry",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "cool-modern",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/sunset.json
+++ b/markdown-sheet/public/themes/presets/sunset.json
@@ -1,0 +1,22 @@
+{
+  "id": "sunset",
+  "name": "日落暖阳",
+  "name_en": "Sunset Warm",
+  "description": "橙黄色系，温暖舒适的日落风格",
+  "description_en": "Orange-yellow for warm and cozy sunset style",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Georgia"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Consolas"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "sunset",
+  "tableStyle": "minimal-gray",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/presets/swiss.json
+++ b/markdown-sheet/public/themes/presets/swiss.json
@@ -1,0 +1,22 @@
+{
+  "id": "swiss",
+  "name": "瑞士极简",
+  "name_en": "Swiss Minimal",
+  "description": "Helvetica 风格，网格系统，极致简洁",
+  "description_en": "Helvetica style with grid system, ultimate simplicity",
+  "author": "Markdown Viewer Team",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Helvetica Neue"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "neutral",
+  "tableStyle": "borderless",
+  "codeTheme": "light-clean"
+}

--- a/markdown-sheet/public/themes/presets/technical.json
+++ b/markdown-sheet/public/themes/presets/technical.json
@@ -1,0 +1,22 @@
+{
+  "id": "technical",
+  "name": "技术文档",
+  "name_en": "Technical",
+  "description": "专为技术文档设计，清晰简洁的极简风格",
+  "description_en": "Designed for technical documentation with clean minimalist style",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Arial"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "technical",
+  "colorScheme": "cool",
+  "tableStyle": "modern-tech",
+  "codeTheme": "cool-modern"
+}

--- a/markdown-sheet/public/themes/presets/typewriter.json
+++ b/markdown-sheet/public/themes/presets/typewriter.json
@@ -1,0 +1,23 @@
+{
+  "id": "typewriter",
+  "name": "复古打字",
+  "name_en": "Typewriter",
+  "description": "Courier New 字体，复古打字机风格",
+  "description_en": "Courier New font with retro typewriter style",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Courier New"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Courier New"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "sepia",
+  "tableStyle": "borderless",
+  "codeTheme": "warm-book",
+  "diagramStyle": "handDrawn"
+}

--- a/markdown-sheet/public/themes/presets/verdana.json
+++ b/markdown-sheet/public/themes/presets/verdana.json
@@ -1,0 +1,22 @@
+{
+  "id": "verdana",
+  "name": "网页显示",
+  "name_en": "Web Display",
+  "description": "Verdana 字体，屏幕显示清晰锐利",
+  "description_en": "Verdana font with clear and sharp screen display",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "Verdana"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Monaco"
+    }
+  },
+  "layoutScheme": "document",
+  "colorScheme": "cool",
+  "tableStyle": "grid",
+  "codeTheme": "cool-modern"
+}

--- a/markdown-sheet/public/themes/presets/water.json
+++ b/markdown-sheet/public/themes/presets/water.json
@@ -1,0 +1,22 @@
+{
+  "id": "water",
+  "name": "水墨诗意",
+  "name_en": "Ink Poetry",
+  "description": "仿宋字体，中国传统水墨美学",
+  "description_en": "FangSong font with traditional Chinese ink aesthetics",
+  "author": "Markdown Viewer Extension",
+  "version": "1.0.0",
+  "fontScheme": {
+    "body": {
+      "fontFamily": "FangSong"
+    },
+    "headings": {},
+    "code": {
+      "fontFamily": "Courier New"
+    }
+  },
+  "layoutScheme": "book",
+  "colorScheme": "sepia",
+  "tableStyle": "borderless",
+  "codeTheme": "warm-book"
+}

--- a/markdown-sheet/public/themes/registry.json
+++ b/markdown-sheet/public/themes/registry.json
@@ -1,0 +1,270 @@
+{
+  "version": "2.0.0",
+  "themes": [
+    {
+      "id": "default",
+      "file": "default.json",
+      "category": "classic",
+      "featured": true,
+      "order": 1
+    },
+    {
+      "id": "academic",
+      "file": "academic.json",
+      "category": "classic",
+      "featured": true,
+      "order": 2
+    },
+    {
+      "id": "business",
+      "file": "business.json",
+      "category": "classic",
+      "featured": true,
+      "order": 3
+    },
+    {
+      "id": "manuscript",
+      "file": "manuscript.json",
+      "category": "classic",
+      "featured": false,
+      "order": 4
+    },
+    {
+      "id": "newspaper",
+      "file": "newspaper.json",
+      "category": "classic",
+      "featured": false,
+      "order": 5
+    },
+    {
+      "id": "palatino",
+      "file": "palatino.json",
+      "category": "reading",
+      "featured": true,
+      "order": 6
+    },
+    {
+      "id": "garamond",
+      "file": "garamond.json",
+      "category": "reading",
+      "featured": true,
+      "order": 7
+    },
+    {
+      "id": "typewriter",
+      "file": "typewriter.json",
+      "category": "reading",
+      "featured": true,
+      "order": 8
+    },
+    {
+      "id": "elegant",
+      "file": "elegant.json",
+      "category": "reading",
+      "featured": true,
+      "order": 9
+    },
+    {
+      "id": "technical",
+      "file": "technical.json",
+      "category": "modern",
+      "featured": true,
+      "order": 10
+    },
+    {
+      "id": "swiss",
+      "file": "swiss.json",
+      "category": "modern",
+      "featured": true,
+      "order": 11
+    },
+    {
+      "id": "minimal",
+      "file": "minimal.json",
+      "category": "modern",
+      "featured": true,
+      "order": 12
+    },
+    {
+      "id": "magazine",
+      "file": "magazine.json",
+      "category": "creative",
+      "featured": true,
+      "order": 13
+    },
+    {
+      "id": "century",
+      "file": "century.json",
+      "category": "creative",
+      "featured": true,
+      "order": 14
+    },
+    {
+      "id": "handwritten",
+      "file": "handwritten.json",
+      "category": "creative",
+      "featured": true,
+      "order": 15
+    },
+    {
+      "id": "verdana",
+      "file": "verdana.json",
+      "category": "creative",
+      "featured": true,
+      "order": 16
+    },
+    {
+      "id": "heiti",
+      "file": "heiti.json",
+      "category": "chinese",
+      "featured": true,
+      "order": 17
+    },
+    {
+      "id": "mixed",
+      "file": "mixed.json",
+      "category": "chinese",
+      "featured": false,
+      "order": 18
+    },
+    {
+      "id": "water",
+      "file": "water.json",
+      "category": "chinese",
+      "featured": true,
+      "order": 19
+    },
+    {
+      "id": "rainbow",
+      "file": "rainbow.json",
+      "category": "playful",
+      "featured": true,
+      "order": 20
+    },
+    {
+      "id": "starry",
+      "file": "starry.json",
+      "category": "playful",
+      "featured": true,
+      "order": 21
+    },
+    {
+      "id": "candy",
+      "file": "candy.json",
+      "category": "playful",
+      "featured": true,
+      "order": 22
+    },
+    {
+      "id": "dinosaur",
+      "file": "dinosaur.json",
+      "category": "playful",
+      "featured": true,
+      "order": 23
+    },
+    {
+      "id": "space",
+      "file": "space.json",
+      "category": "playful",
+      "featured": true,
+      "order": 24
+    },
+    {
+      "id": "garden",
+      "file": "garden.json",
+      "category": "playful",
+      "featured": true,
+      "order": 25
+    },
+    {
+      "id": "forest",
+      "file": "forest.json",
+      "category": "nature",
+      "featured": true,
+      "order": 26
+    },
+    {
+      "id": "ocean",
+      "file": "ocean.json",
+      "category": "nature",
+      "featured": true,
+      "order": 27
+    },
+    {
+      "id": "coral",
+      "file": "coral.json",
+      "category": "nature",
+      "featured": true,
+      "order": 28
+    },
+    {
+      "id": "sunset",
+      "file": "sunset.json",
+      "category": "nature",
+      "featured": true,
+      "order": 29
+    }
+  ],
+  "categories": {
+    "classic": {
+      "name": "经典文档",
+      "name_en": "Classic Document",
+      "description": "传统正式的文档风格，适合公文、报告、论文",
+      "description_en": "Traditional formal styles for official documents, reports, papers",
+      "order": 1
+    },
+    "reading": {
+      "name": "书籍阅读",
+      "name_en": "Book & Reading",
+      "description": "舒适的长文阅读体验，适合小说、杂志、博客",
+      "description_en": "Comfortable long-form reading for novels, magazines, blogs",
+      "order": 2
+    },
+    "modern": {
+      "name": "现代科技",
+      "name_en": "Modern Tech",
+      "description": "简洁现代的设计风格，适合技术文档、产品说明",
+      "description_en": "Clean modern design for technical docs and products",
+      "order": 3
+    },
+    "creative": {
+      "name": "创意表达",
+      "name_en": "Creative Expression",
+      "description": "富有个性的创意风格，适合博客、设计、创意写作",
+      "description_en": "Creative styles for blogs, design, creative writing",
+      "order": 4
+    },
+    "chinese": {
+      "name": "中文排版",
+      "name_en": "Chinese Typography",
+      "description": "专为中文优化的排版风格",
+      "description_en": "Typography optimized for Chinese content",
+      "order": 5
+    },
+    "playful": {
+      "name": "缤纷童趣",
+      "name_en": "Colorful & Playful",
+      "description": "活泼多彩的风格，适合学生作业、儿童内容",
+      "description_en": "Vibrant playful styles for students and kids",
+      "order": 6
+    },
+    "nature": {
+      "name": "自然色彩",
+      "name_en": "Nature Colors",
+      "description": "取自自然的配色，温暖舒适的视觉体验",
+      "description_en": "Nature-inspired colors for warm visual experience",
+      "order": 7
+    }
+  },
+  "recommendations": {
+    "default": "default",
+    "academic": "academic",
+    "business": "business",
+    "technical": "technical",
+    "reading": "garamond",
+    "book": "palatino",
+    "modern": "swiss",
+    "screen": "verdana",
+    "creative": "magazine"
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/academic.json
+++ b/markdown-sheet/public/themes/table-styles/academic.json
@@ -1,0 +1,30 @@
+{
+  "id": "academic",
+  "name": "学术风格",
+  "name_en": "Academic",
+  "description": "双线表头 + 单线分隔，适合论文和学术文档",
+  "description_en": "Double-line header + single-line separators, ideal for papers and academic documents",
+  "border": {
+    "headerTop": {
+      "width": "1.5pt",
+      "style": "double"
+    },
+    "headerBottom": {
+      "width": "1.5pt",
+      "style": "single"
+    },
+    "lastRowBottom": {
+      "width": "1.5pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "6pt"
+  },
+  "zebra": {
+    "enabled": false
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/borderless.json
+++ b/markdown-sheet/public/themes/table-styles/borderless.json
@@ -1,0 +1,26 @@
+{
+  "id": "borderless",
+  "name": "无边框",
+  "name_en": "Borderless",
+  "description": "仅表头有下边框",
+  "description_en": "Only header has bottom border",
+  "border": {
+    "headerBottom": {
+      "width": "2pt",
+      "style": "single"
+    },
+    "lastRowBottom": {
+      "width": "1pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "8pt"
+  },
+  "zebra": {
+    "enabled": false
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/compact.json
+++ b/markdown-sheet/public/themes/table-styles/compact.json
@@ -1,0 +1,24 @@
+{
+  "id": "compact",
+  "name": "紧凑型",
+  "name_en": "Compact",
+  "description": "小间距 + 细边框，适合数据密集型表格",
+  "description_en": "Small padding + thin borders, ideal for data-heavy tables",
+  "border": {
+    "all": {
+      "width": "0.5pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold",
+    "fontSize": "10pt"
+  },
+  "cell": {
+    "padding": "4pt",
+    "fontSize": "10pt"
+  },
+  "zebra": {
+    "enabled": true
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/grid.json
+++ b/markdown-sheet/public/themes/table-styles/grid.json
@@ -1,0 +1,22 @@
+{
+  "id": "grid",
+  "name": "网格样式",
+  "name_en": "Grid Style",
+  "description": "完整边框，表头浅灰背景，斑马纹",
+  "description_en": "Full borders, light gray header, zebra stripes",
+  "border": {
+    "all": {
+      "width": "1pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "8pt"
+  },
+  "zebra": {
+    "enabled": true
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/high-contrast.json
+++ b/markdown-sheet/public/themes/table-styles/high-contrast.json
@@ -1,0 +1,22 @@
+{
+  "id": "high-contrast",
+  "name": "高对比度",
+  "name_en": "High Contrast",
+  "description": "黑白高对比 + 粗边框，适合打印和可访问性需求",
+  "description_en": "Black & white high contrast with thick borders, ideal for printing and accessibility",
+  "border": {
+    "all": {
+      "width": "2pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "8pt"
+  },
+  "zebra": {
+    "enabled": true
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/minimal-gray.json
+++ b/markdown-sheet/public/themes/table-styles/minimal-gray.json
@@ -1,0 +1,26 @@
+{
+  "id": "minimal-gray",
+  "name": "极简灰调",
+  "name_en": "Minimal Gray",
+  "description": "仅横向边框 + 灰色调 + 简洁美观",
+  "description_en": "Horizontal borders only + gray tones + clean look",
+  "border": {
+    "headerBottom": {
+      "width": "1.5pt",
+      "style": "single"
+    },
+    "rowBottom": {
+      "width": "1pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "8pt"
+  },
+  "zebra": {
+    "enabled": false
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/modern-tech.json
+++ b/markdown-sheet/public/themes/table-styles/modern-tech.json
@@ -1,0 +1,34 @@
+{
+  "id": "modern-tech",
+  "name": "现代科技",
+  "name_en": "Modern Tech",
+  "description": "蓝色主题 + 圆角边框，适合技术文档和产品说明",
+  "description_en": "Blue theme with rounded borders, ideal for tech docs and product guides",
+  "border": {
+    "headerTop": {
+      "width": "2pt",
+      "style": "single"
+    },
+    "headerBottom": {
+      "width": "2pt",
+      "style": "single"
+    },
+    "rowBottom": {
+      "width": "1pt",
+      "style": "single"
+    },
+    "lastRowBottom": {
+      "width": "2pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "10pt"
+  },
+  "zebra": {
+    "enabled": false
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/professional.json
+++ b/markdown-sheet/public/themes/table-styles/professional.json
@@ -1,0 +1,34 @@
+{
+  "id": "professional",
+  "name": "专业风格",
+  "name_en": "Professional",
+  "description": "粗表头边框 + 细分隔线",
+  "description_en": "Thick header border + thin separators",
+  "border": {
+    "headerTop": {
+      "width": "2pt",
+      "style": "single"
+    },
+    "headerBottom": {
+      "width": "2pt",
+      "style": "single"
+    },
+    "rowBottom": {
+      "width": "1pt",
+      "style": "single"
+    },
+    "lastRowBottom": {
+      "width": "2pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "8pt"
+  },
+  "zebra": {
+    "enabled": false
+  }
+}

--- a/markdown-sheet/public/themes/table-styles/zebra.json
+++ b/markdown-sheet/public/themes/table-styles/zebra.json
@@ -1,0 +1,22 @@
+{
+  "id": "zebra",
+  "name": "斑马纹",
+  "name_en": "Zebra",
+  "description": "奇偶行不同背景色，无边框",
+  "description_en": "Alternating row colors, no borders",
+  "border": {
+    "headerBottom": {
+      "width": "1pt",
+      "style": "single"
+    }
+  },
+  "header": {
+    "fontWeight": "bold"
+  },
+  "cell": {
+    "padding": "8pt"
+  },
+  "zebra": {
+    "enabled": true
+  }
+}

--- a/markdown-sheet/src/App.tsx
+++ b/markdown-sheet/src/App.tsx
@@ -930,8 +930,34 @@ function App() {
         defaultPath: `${title.replace(/\.md$/i, "")}.docx`,
       });
       if (path) {
+        // Extract pre-rendered mermaid SVGs from preview DOM.
+        // processSvgForStandaloneUse inlines computed styles, converts
+        // <foreignObject> to <text>, and removes <style> blocks so the
+        // SVG can be loaded into an <img> for canvas rendering.
+        const { processSvgForStandaloneUse } = await import("./components/MarkdownPreview");
+        const mermaidSvgs: (string | null)[] = [];
+        const previewEl = previewRef.current;
+        if (previewEl) {
+          const placeholders = previewEl.querySelectorAll(".mermaid-placeholder");
+          for (const ph of Array.from(placeholders)) {
+            const svg = ph.querySelector(".mermaid-rendered svg") as SVGSVGElement | null;
+            if (svg) {
+              try {
+                mermaidSvgs.push(processSvgForStandaloneUse(svg));
+              } catch {
+                mermaidSvgs.push(null);
+              }
+            } else {
+              mermaidSvgs.push(null);
+            }
+          }
+        }
+
+        const fontKey = localStorage.getItem("md-preview-font") || "meiryo";
         const docxData = await exportMarkdownToDocx(content, {
           baseDir: activeFile || undefined,
+          mermaidSvgs,
+          fontKey,
         });
         await writeFile(path, docxData);
         showToast("DOCXをエクスポートしました");

--- a/markdown-sheet/src/App.tsx
+++ b/markdown-sheet/src/App.tsx
@@ -1697,6 +1697,7 @@ function App() {
             )}
             <MarkdownPreview
               content={content}
+              filePath={activeFile}
               previewRef={previewRef}
               aiSettings={aiSettings}
               onUpdateMermaidBlock={handleUpdateMermaidBlock}

--- a/markdown-sheet/src/App.tsx
+++ b/markdown-sheet/src/App.tsx
@@ -916,6 +916,32 @@ function App() {
     }
   }, [activeFile]);
 
+  // --- DOCX Export ---
+  const handleExportDocx = useCallback(async () => {
+    const content = contentRef.current;
+    if (!content) return;
+    try {
+      const { exportMarkdownToDocx } = await import("./lib/docx/docx-exporter");
+      const title = activeFile
+        ? activeFile.split(/[\\/]/).pop() || "document"
+        : "document";
+      const path = await save({
+        filters: [{ name: "Word Document", extensions: ["docx"] }],
+        defaultPath: `${title.replace(/\.md$/i, "")}.docx`,
+      });
+      if (path) {
+        const docxData = await exportMarkdownToDocx(content, {
+          baseDir: activeFile || undefined,
+        });
+        await writeFile(path, docxData);
+        showToast("DOCXをエクスポートしました");
+      }
+    } catch (error) {
+      console.error("DOCX export error:", error);
+      showToast("DOCXエクスポートに失敗しました", true);
+    }
+  }, [activeFile]);
+
   // --- CSV Export ---
   const handleExportCsv = useCallback(
     async (tableIndex: number) => {
@@ -1464,6 +1490,7 @@ function App() {
         onToggleTheme={toggleTheme}
         onExportPdf={handleExportPdf}
         onExportHtml={handleExportHtml}
+        onExportDocx={handleExportDocx}
         onCopyRichText={handleCopyRichText}
         onPasteFromClipboard={handlePasteFromClipboard}
         onToggleEditor={() => setEditorVisible((v) => !v)}

--- a/markdown-sheet/src/components/MarkdownPreview.tsx
+++ b/markdown-sheet/src/components/MarkdownPreview.tsx
@@ -388,7 +388,7 @@ const MarkdownPreview: FC<Props> = ({
 
           // DOM 挿入後に getComputedStyle でスタイルを読み取り PowerPoint 互換 SVG を生成。
           // 挿入前だと <style> の CSS が未適用のまま処理されてテキスト色が失われる。
-          const processedSvg = processSvgForPowerPoint(svgEl);
+          const processedSvg = processSvgForStandaloneUse(svgEl);
 
           actionsDiv.querySelector(".mermaid-copy-svg")?.addEventListener("click", () => {
             navigator.clipboard.writeText(processedSvg);
@@ -582,7 +582,7 @@ const MarkdownPreview: FC<Props> = ({
  *   B. <foreignObject> を SVG <text> 要素に変換（mermaid v11 がフローチャート以外で
  *      htmlLabels を無視して foreignObject を使う場合に対応）
  */
-function processSvgForPowerPoint(liveSvgEl: SVGSVGElement): string {
+export function processSvgForStandaloneUse(liveSvgEl: SVGSVGElement): string {
   const SVG_NS = "http://www.w3.org/2000/svg";
   const SAFE_FONT = "Meiryo, Yu Gothic, Segoe UI, Arial, sans-serif";
 

--- a/markdown-sheet/src/components/MarkdownPreview.tsx
+++ b/markdown-sheet/src/components/MarkdownPreview.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useRef, useState } from "react";
 import type { AiSettings } from "../types";
 import { callAI } from "../lib/callAI";
 import { marked } from "marked";
+import { readFile } from "@tauri-apps/plugin-fs";
 import hljs from "highlight.js";
 import "highlight.js/styles/atom-one-dark.css";
 import mermaid from "mermaid";
@@ -131,6 +132,7 @@ const FONT_MAP: Record<string, string> = {
 
 interface Props {
   content: string;
+  filePath?: string | null;
   previewRef?: React.RefObject<HTMLDivElement | null>;
   aiSettings?: AiSettings;
   onUpdateMermaidBlock?: (blockIndex: number, newSource: string) => void;
@@ -138,6 +140,7 @@ interface Props {
 
 const MarkdownPreview: FC<Props> = ({
   content,
+  filePath,
   previewRef: externalRef,
   aiSettings,
   onUpdateMermaidBlock,
@@ -196,10 +199,58 @@ const MarkdownPreview: FC<Props> = ({
   // HTML を mdContentRef に手動で書き込む。
   // dangerouslySetInnerHTML を使わないことで React の reconciliation から切り離し、
   // StrictMode の remount 時に innerHTML がリセットされる問題を回避する。
+  // また、相対画像パスをローカルファイルから blob URL に変換する。
+  const blobUrlsRef = useRef<string[]>([]);
   useEffect(() => {
+    // 前回の blob URL を解放
+    for (const url of blobUrlsRef.current) URL.revokeObjectURL(url);
+    blobUrlsRef.current = [];
+
     const div = mdContentRef.current;
-    if (div) div.innerHTML = html;
-  }, [html]);
+    if (!div) return;
+    div.innerHTML = html;
+
+    if (!filePath) return;
+    const dir = filePath.replace(/[\\/][^\\/]+$/, "");
+    const imgs = Array.from(div.querySelectorAll<HTMLImageElement>("img"));
+    const blobUrls = blobUrlsRef.current;
+
+    (async () => {
+      for (const img of imgs) {
+        const src = img.getAttribute("src");
+        if (!src) continue;
+        if (/^(https?:|data:|blob:)/i.test(src)) continue;
+
+        // 相対パスを絶対パスに解決
+        const combined = dir.replace(/\\/g, "/") + "/" + src;
+        const parts = combined.split("/");
+        const resolved: string[] = [];
+        for (const p of parts) {
+          if (p === "..") resolved.pop();
+          else if (p !== ".") resolved.push(p);
+        }
+        const absolutePath = resolved.join("/");
+
+        try {
+          const data = await readFile(absolutePath);
+          const ext = src.split(".").pop()?.toLowerCase() ?? "";
+          const mime =
+            ext === "svg" ? "image/svg+xml" :
+            ext === "png" ? "image/png" :
+            ext === "gif" ? "image/gif" :
+            ext === "webp" ? "image/webp" :
+            ext === "bmp" ? "image/bmp" :
+            "image/jpeg";
+          const blob = new Blob([data], { type: mime });
+          const url = URL.createObjectURL(blob);
+          blobUrls.push(url);
+          img.src = url;
+        } catch {
+          // ファイルが見つからない場合はスキップ
+        }
+      }
+    })();
+  }, [html, filePath]);
 
   // Mermaid ブロック + KaTeX をレンダリング
   useEffect(() => {

--- a/markdown-sheet/src/components/Settings.tsx
+++ b/markdown-sheet/src/components/Settings.tsx
@@ -82,7 +82,7 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
           },
           body: JSON.stringify({
             messages: [{ role: "user", content: "hi" }],
-            max_tokens: 5,
+            max_completion_tokens: 5,
           }),
         });
         if (resp.ok) {

--- a/markdown-sheet/src/components/Settings.tsx
+++ b/markdown-sheet/src/components/Settings.tsx
@@ -5,7 +5,7 @@ import "./Settings.css";
 const PROVIDERS: {
   id: string;
   label: string;
-  format: "openai" | "anthropic";
+  format: "openai" | "anthropic" | "azure";
   baseUrl: string;
   model: string;
 }[] = [
@@ -14,6 +14,7 @@ const PROVIDERS: {
   { id: "grok",      label: "Grok / xAI (無料枠あり)",   format: "openai",    baseUrl: "https://api.x.ai/v1",                                      model: "grok-2-latest"            },
   { id: "gemini",    label: "Gemini / Google (無料枠あり)", format: "openai", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai/", model: "gemini-2.0-flash"         },
   { id: "openai",    label: "OpenAI (ChatGPT)",           format: "openai",    baseUrl: "https://api.openai.com/v1",                                model: "gpt-4o"                   },
+  { id: "azure",     label: "Azure OpenAI",               format: "azure",     baseUrl: "https://{resource}.openai.azure.com/openai/deployments/{deployment}", model: "gpt-5.1" },
   { id: "anthropic", label: "Claude / Anthropic",         format: "anthropic", baseUrl: "https://api.anthropic.com/v1",                             model: "claude-haiku-4-5-20251001"},
   { id: "custom",    label: "カスタム (さくらのAI など)", format: "openai",    baseUrl: "",                                                         model: ""                         },
 ];
@@ -63,6 +64,25 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
             model: local.model,
             max_tokens: 5,
             messages: [{ role: "user", content: "hi" }],
+          }),
+        });
+        if (resp.ok) {
+          setTestMsg({ text: "接続成功！", ok: true });
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          setTestMsg({ text: `エラー: ${err?.error?.message || resp.statusText}`, ok: false });
+        }
+      } else if (local.apiFormat === "azure") {
+        const url = local.baseUrl.replace(/\/$/, "") + "/chat/completions?api-version=2024-12-01-preview";
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "api-key": local.apiKey,
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "hi" }],
+            max_tokens: 5,
           }),
         });
         if (resp.ok) {
@@ -128,7 +148,7 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
           </select>
 
           <div className="settings-format-badge">
-            形式: <strong>{local.apiFormat === "anthropic" ? "Anthropic Messages API" : "OpenAI 互換"}</strong>
+            形式: <strong>{local.apiFormat === "anthropic" ? "Anthropic Messages API" : local.apiFormat === "azure" ? "Azure OpenAI" : "OpenAI 互換"}</strong>
           </div>
 
           {/* API キー */}
@@ -138,7 +158,7 @@ const Settings: FC<Props> = ({ settings, onSave, onClose }) => {
             className="settings-input"
             value={local.apiKey}
             onChange={(e) => { setLocal((s) => ({ ...s, apiKey: e.target.value })); setTestMsg(null); }}
-            placeholder={local.apiFormat === "anthropic" ? "sk-ant-..." : "sk-..."}
+            placeholder={local.apiFormat === "anthropic" ? "sk-ant-..." : local.apiFormat === "azure" ? "Azure API キー" : "sk-..."}
             spellCheck={false}
           />
 

--- a/markdown-sheet/src/components/Toolbar.tsx
+++ b/markdown-sheet/src/components/Toolbar.tsx
@@ -21,6 +21,7 @@ interface Props {
   onToggleTheme: () => void;
   onExportPdf: () => void;
   onExportHtml: () => void;
+  onExportDocx: () => void;
   onCopyRichText: () => void;
   onPasteFromClipboard: () => void;
   onToggleEditor: () => void;
@@ -46,6 +47,7 @@ const Toolbar: FC<Props> = ({
   onToggleTheme,
   onExportPdf,
   onExportHtml,
+  onExportDocx,
   onCopyRichText,
   onPasteFromClipboard,
   onToggleEditor,
@@ -162,6 +164,9 @@ const Toolbar: FC<Props> = ({
             </button>
             <button onClick={onExportHtml} title="HTMLとしてエクスポート">
               HTML
+            </button>
+            <button onClick={onExportDocx} title="DOCXとしてエクスポート">
+              DOCX
             </button>
           </>
         )}

--- a/markdown-sheet/src/lib/callAI.ts
+++ b/markdown-sheet/src/lib/callAI.ts
@@ -41,7 +41,7 @@ export async function callAI(
           { role: "system", content: systemPrompt },
           { role: "user", content: userContent },
         ],
-        max_tokens: 2000,
+        max_completion_tokens: 2000,
       }),
     });
   } else {

--- a/markdown-sheet/src/lib/callAI.ts
+++ b/markdown-sheet/src/lib/callAI.ts
@@ -28,6 +28,22 @@ export async function callAI(
         messages: [{ role: "user", content: userContent }],
       }),
     });
+  } else if (apiFormat === "azure") {
+    const url = baseUrl.replace(/\/$/, "") + "/chat/completions?api-version=2024-12-01-preview";
+    resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": apiKey,
+      },
+      body: JSON.stringify({
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userContent },
+        ],
+        max_tokens: 2000,
+      }),
+    });
   } else {
     const url = baseUrl.replace(/\/$/, "") + "/chat/completions";
     resp = await fetch(url, {

--- a/markdown-sheet/src/lib/docx/docx-blockquote-converter.ts
+++ b/markdown-sheet/src/lib/docx/docx-blockquote-converter.ts
@@ -1,0 +1,180 @@
+// Blockquote conversion for DOCX export
+// Uses a single-cell table to create a true container that supports nested content
+
+import {
+  Paragraph,
+  Table,
+  TableRow,
+  TableCell,
+  AlignmentType,
+  BorderStyle,
+  WidthType,
+  TableLayoutType,
+  convertInchesToTwip,
+  type IParagraphOptions,
+  type ParagraphChild,
+  type FileChild,
+} from 'docx';
+import type { DOCXThemeStyles, DOCXBlockquoteNode, DOCXASTNode } from './types';
+import type { InlineResult, InlineNode } from './docx-inline-converter';
+
+type ConvertInlineNodesFunction = (children: InlineNode[], options?: { color?: string }) => Promise<InlineResult[]>;
+type ConvertChildNodeFunction = (node: DOCXASTNode, blockquoteNestLevel?: number) => Promise<FileChild | FileChild[] | null>;
+
+interface BlockquoteConverterOptions {
+  themeStyles: DOCXThemeStyles;
+  convertInlineNodes: ConvertInlineNodesFunction;
+  convertChildNode?: ConvertChildNodeFunction;
+}
+
+export interface BlockquoteConverter {
+  convertBlockquote(node: DOCXBlockquoteNode, listLevel?: number): Promise<Table>;
+  setConvertChildNode(fn: ConvertChildNodeFunction): void;
+}
+
+// Blockquote style constants
+const BLOCKQUOTE_STYLES = {
+  leftBorderSize: 18,
+};
+
+/**
+ * Create a blockquote converter using table-based approach
+ * This allows true nesting and supports any content type inside blockquotes
+ * @param options - Configuration options
+ * @returns Blockquote converter
+ */
+export function createBlockquoteConverter({ themeStyles, convertInlineNodes, convertChildNode: initialConvertChildNode }: BlockquoteConverterOptions): BlockquoteConverter {
+  const defaultSpacing = themeStyles.default?.paragraph?.spacing || { before: 0, line: 276 };
+  const defaultLineSpacing = defaultSpacing.line ?? 276;
+  
+  // Calculate cell padding to compensate for line height bottom spacing
+  // Word's line height adds extra space BELOW text (not evenly distributed)
+  // So we need to add equivalent top padding to balance the visual appearance
+  const lineSpacingExtra = defaultLineSpacing - 240; // Extra spacing from line height (240 = single line)
+  const basePadding = 80;
+  const cellPadding = {
+    top: basePadding + lineSpacingExtra, // Compensate for full bottom spacing from line height
+    bottom: 0,
+    left: 200,
+    right: 100,
+  };
+
+  // Mutable reference to convertChildNode (set later to avoid circular dependency)
+  let convertChildNode: ConvertChildNodeFunction | undefined = initialConvertChildNode;
+
+  /**
+   * Set the convertChildNode function (called after all converters are initialized)
+   */
+  function setConvertChildNode(fn: ConvertChildNodeFunction): void {
+    convertChildNode = fn;
+  }
+
+  /**
+   * Convert a paragraph node inside blockquote
+   */
+  async function convertBlockquoteParagraph(child: DOCXASTNode, isFirst: boolean): Promise<Paragraph> {
+    const children = await convertInlineNodes(child.children as InlineNode[]);
+    
+    const paragraphConfig: IParagraphOptions = {
+      children: children as ParagraphChild[],
+      spacing: { 
+        before: isFirst ? 0 : 120, 
+        after: 0, 
+        line: defaultLineSpacing 
+      },
+      alignment: AlignmentType.LEFT,
+    };
+    
+    return new Paragraph(paragraphConfig);
+  }
+
+  /**
+   * Convert blockquote node to a DOCX Table (single-cell table as container)
+   * @param node - Blockquote AST node
+   * @param listLevel - List nesting level for indentation (default: 0)
+   * @param nestLevel - Blockquote nesting level within blockquotes (default: 0)
+   * @returns DOCX Table representing the blockquote
+   */
+  async function convertBlockquote(node: DOCXBlockquoteNode, listLevel = 0, nestLevel = 0): Promise<Table> {
+    const cellChildren: FileChild[] = [];
+
+    let isFirst = true;
+    for (const child of node.children) {
+      if (child.type === 'paragraph') {
+        cellChildren.push(await convertBlockquoteParagraph(child, isFirst));
+        isFirst = false;
+      } else if (child.type === 'blockquote') {
+        // Nested blockquote: recursively create another table (keep same listLevel, increment nestLevel)
+        const nestedTable = await convertBlockquote(child as DOCXBlockquoteNode, listLevel, nestLevel + 1);
+        cellChildren.push(nestedTable);
+        isFirst = false;
+      } else if (convertChildNode) {
+        // Use generic converter for other node types (code, table, etc.)
+        // Pass blockquote nest level + 1 for proper right margin compensation
+        const converted = await convertChildNode(child, nestLevel + 1);
+        if (converted) {
+          if (Array.isArray(converted)) {
+            cellChildren.push(...converted);
+          } else {
+            cellChildren.push(converted);
+          }
+        }
+        isFirst = false;
+      }
+    }
+
+    // Ensure at least one paragraph in the cell (Word requirement)
+    if (cellChildren.length === 0) {
+      cellChildren.push(new Paragraph({ text: '' }));
+    }
+
+    // Create the table cell with blockquote styling
+    const cell = new TableCell({
+      children: cellChildren,
+      margins: cellPadding,
+      borders: {
+        top: { style: BorderStyle.SINGLE, size: 0, color: 'FFFFFF' },
+        bottom: { style: BorderStyle.SINGLE, size: 0, color: 'FFFFFF' },
+        right: { style: BorderStyle.SINGLE, size: 0, color: 'FFFFFF' },
+        left: { 
+          style: BorderStyle.SINGLE, 
+          size: BLOCKQUOTE_STYLES.leftBorderSize, 
+          color: themeStyles.blockquoteColor 
+        },
+      },
+    });
+
+    // Create single-row table
+    const row = new TableRow({
+      children: [cell],
+    });
+
+    // Calculate indent for this blockquote level
+    // For top-level (nestLevel=0): use listLevel indent if inside a list
+    // For nested blockquotes (nestLevel>0): use a fixed small indent relative to parent
+    const listIndent = listLevel > 0 ? 0.5 * listLevel : 0;
+    const blockquoteIndent = 0.2 * nestLevel; // Fixed indent per nesting level
+    const totalIndent = listIndent + blockquoteIndent;
+
+    // Width calculation:
+    // - Top level: full content width minus indent
+    // - Nested: use 100% of parent cell width (parent already constrains it)
+    const isNested = nestLevel > 0;
+    
+    // Create table with appropriate width
+    const table = new Table({
+      rows: [row],
+      width: isNested 
+        ? { size: 100, type: WidthType.PERCENTAGE }  // Nested: fill parent cell
+        : { size: convertInchesToTwip(6.5 - listIndent), type: WidthType.DXA },  // Top level: calculated width
+      layout: TableLayoutType.FIXED,
+      indent: isNested
+        ? undefined  // Nested: no extra indent, align with parent text
+        : (listIndent > 0 ? { size: convertInchesToTwip(listIndent), type: WidthType.DXA } : undefined),  // Top level: list indent only
+    });
+
+    return table;
+  }
+
+  return { convertBlockquote, setConvertChildNode };
+}

--- a/markdown-sheet/src/lib/docx/docx-code-highlighter.ts
+++ b/markdown-sheet/src/lib/docx/docx-code-highlighter.ts
@@ -1,0 +1,204 @@
+// DOCX Code Highlighter
+// Functions for syntax highlighting in DOCX export
+
+import { TextRun } from 'docx';
+import hljs from 'highlight.js/lib/common';
+import type { DOCXThemeStyles } from './types';
+
+export interface CodeHighlighter {
+  getHighlightColor(classList: string | string[] | DOMTokenList | null): string | null;
+  appendCodeTextRuns(text: string, runs: TextRun[], color: string | null): void;
+  collectHighlightedRuns(node: Node, runs: TextRun[], inheritedColor?: string | null): void;
+  getHighlightedRunsForCode(code: string, language: string | null | undefined): TextRun[];
+}
+
+// Default code colors
+const DEFAULT_CODE_COLORS = {
+  foreground: '24292E',
+  colors: {} as Record<string, string>
+};
+
+// Default code character style
+const DEFAULT_CODE_STYLE = {
+  font: 'Consolas',
+  size: 20
+};
+
+/**
+ * Create a code highlighter for DOCX export
+ * @param themeStyles - Theme configuration with code colors
+ * @returns Highlighter instance with methods
+ */
+export function createCodeHighlighter(themeStyles: DOCXThemeStyles | null): CodeHighlighter {
+  // Get code colors with defaults
+  const codeColors = themeStyles?.codeColors || DEFAULT_CODE_COLORS;
+  const codeStyle = themeStyles?.characterStyles?.code || DEFAULT_CODE_STYLE;
+  
+  /**
+   * Get highlight color from CSS class list
+   * @param classList - CSS classes
+   * @returns Hex color without # or null
+   */
+  function getHighlightColor(classList: string | string[] | DOMTokenList | null): string | null {
+    if (!classList) {
+      return null;
+    }
+
+    const tokens: string[] = Array.isArray(classList)
+      ? classList
+      : typeof classList === 'string'
+        ? classList.split(/\s+/)
+        : Array.from(classList);
+
+    for (const rawToken of tokens) {
+      if (!rawToken) {
+        continue;
+      }
+
+      const token = rawToken.startsWith('hljs-') ? rawToken.slice(5) : rawToken;
+      if (!token) {
+        continue;
+      }
+
+      const normalized = token.replace(/-/g, '_');
+
+      // Use theme color
+      const themeColor = codeColors.colors?.[normalized];
+      if (themeColor) {
+        return themeColor.replace('#', '');
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Append code text runs with proper formatting
+   * @param text - Text content
+   * @param runs - Array to append runs to
+   * @param color - Hex color
+   */
+  function appendCodeTextRuns(text: string, runs: TextRun[], color: string | null): void {
+    if (text === '') {
+      return;
+    }
+
+    const segments = text.split('\n');
+    const lastIndex = segments.length - 1;
+    const defaultColor = codeColors.foreground;
+    const appliedColor = color || defaultColor;
+
+    // Use theme code font and size (already converted to half-points in theme-to-docx.js)
+    const codeFont = codeStyle.font;
+    const codeSize = codeStyle.size;
+
+    segments.forEach((segment, index) => {
+      if (segment.length > 0) {
+        runs.push(new TextRun({
+          text: segment,
+          font: codeFont,
+          size: codeSize,
+          color: appliedColor,
+        }));
+      }
+
+      if (index < lastIndex) {
+        runs.push(new TextRun({ text: '', break: 1 }));
+      }
+    });
+  }
+
+  /**
+   * Recursively collect runs from highlighted HTML nodes
+   * @param node - DOM node
+   * @param runs - Array to append runs to
+   * @param inheritedColor - Inherited color from parent
+   */
+  function collectHighlightedRuns(node: Node, runs: TextRun[], inheritedColor: string | null = null): void {
+    if (inheritedColor === null) {
+      inheritedColor = codeColors.foreground;
+    }
+    if (!node) {
+      return;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      appendCodeTextRuns(node.nodeValue || '', runs, inheritedColor);
+      return;
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+
+    const element = node as Element;
+    const elementColor = getHighlightColor(element.classList) || inheritedColor;
+    const nextColor = elementColor || inheritedColor;
+
+    node.childNodes.forEach((child) => {
+      collectHighlightedRuns(child, runs, nextColor);
+    });
+  }
+
+  /**
+   * Get highlighted TextRuns for code
+   * @param code - Code content
+   * @param language - Programming language
+   * @returns Array of TextRun elements
+   */
+  function getHighlightedRunsForCode(code: string, language: string | null | undefined): TextRun[] {
+    const runs: TextRun[] = [];
+
+    if (!code) {
+      // Use theme code font and size (already converted to half-points in theme-to-docx.js)
+      const codeFont = codeStyle.font;
+      const codeSize = codeStyle.size;
+      const defaultColor = codeColors.foreground;
+
+      runs.push(new TextRun({
+        text: '',
+        font: codeFont,
+        size: codeSize,
+        color: defaultColor,
+      }));
+      return runs;
+    }
+
+    let highlightResult: ReturnType<typeof hljs.highlight> | null = null;
+
+    try {
+      if (language && hljs.getLanguage(language)) {
+        highlightResult = hljs.highlight(code, {
+          language,
+          ignoreIllegals: true,
+        });
+      } else {
+        // No language specified - don't highlight (consistent with Web behavior)
+        highlightResult = null;
+      }
+    } catch (error) {
+      console.warn('Highlight error:', error);
+    }
+
+    const defaultColor = codeColors.foreground;
+
+    if (highlightResult && highlightResult.value) {
+      const container = document.createElement('div');
+      container.innerHTML = highlightResult.value;
+      collectHighlightedRuns(container, runs, defaultColor);
+    }
+
+    if (runs.length === 0) {
+      appendCodeTextRuns(code, runs, defaultColor);
+    }
+
+    return runs;
+  }
+
+  return {
+    getHighlightColor,
+    appendCodeTextRuns,
+    collectHighlightedRuns,
+    getHighlightedRunsForCode
+  };
+}

--- a/markdown-sheet/src/lib/docx/docx-exporter.ts
+++ b/markdown-sheet/src/lib/docx/docx-exporter.ts
@@ -9,6 +9,7 @@ import {
   Packer,
   Paragraph,
   TextRun,
+  ImageRun,
   HeadingLevel,
   AlignmentType,
   BorderStyle,
@@ -26,6 +27,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import { visit } from 'unist-util-visit';
 import { loadThemeForDOCX } from './theme-loader';
+import { calculateImageDimensions } from './docx-image-utils';
 import { mathJaxReady, convertLatex2Math } from './docx-math-converter';
 import { createCodeHighlighter, type CodeHighlighter } from './docx-code-highlighter';
 import { createTableConverter, type TableConverter } from './docx-table-converter';
@@ -50,7 +52,23 @@ import type {
 export interface ExportDocxOptions {
   /** Base directory for resolving relative image paths */
   baseDir?: string;
+  /** Pre-rendered mermaid SVG strings extracted from the preview DOM (one per mermaid block, null if render failed) */
+  mermaidSvgs?: (string | null)[];
+  /** UI font key from preview settings (e.g. "meiryo", "yugothic"). Overrides the theme font. */
+  fontKey?: string;
 }
+
+// Maps the UI font selector keys to DOCX font properties
+const DOCX_FONT_KEY_MAP: Record<string, { ascii: string; eastAsia: string }> = {
+  system:   { ascii: 'Segoe UI',    eastAsia: 'Meiryo' },
+  meiryo:   { ascii: 'Meiryo',      eastAsia: 'Meiryo' },
+  pgothic:  { ascii: 'MS PGothic',  eastAsia: 'MS PGothic' },
+  yugothic: { ascii: 'Yu Gothic',   eastAsia: 'Yu Gothic' },
+  yumin:    { ascii: 'Yu Mincho',   eastAsia: 'Yu Mincho' },
+  msmin:    { ascii: 'MS PMincho',  eastAsia: 'MS PMincho' },
+  serif:    { ascii: 'Georgia',     eastAsia: 'Yu Mincho' },
+  mono:     { ascii: 'Consolas',    eastAsia: 'Meiryo' },
+};
 
 // ============================================================================
 // Image fetching
@@ -191,6 +209,18 @@ export async function exportMarkdownToDocx(
   // Load theme
   const themeStyles = await loadThemeForDOCX('default');
 
+  // Override font if the user selected a specific font in the UI
+  if (options.fontKey && DOCX_FONT_KEY_MAP[options.fontKey]) {
+    const { ascii, eastAsia } = DOCX_FONT_KEY_MAP[options.fontKey];
+    const docxFont = { ascii, eastAsia, hAnsi: ascii, cs: ascii };
+    // Override body default font
+    themeStyles.default.run.font = docxFont;
+    // Override heading fonts
+    for (const style of Object.values(themeStyles.paragraphStyles)) {
+      style.run.font = docxFont;
+    }
+  }
+
   // Initialize MathJax
   await mathJaxReady();
 
@@ -233,6 +263,149 @@ export async function exportMarkdownToDocx(
     incrementListInstanceCounter: () => listInstanceCounter++,
   });
 
+  // ---- Mermaid rendering ----
+  // Uses pre-rendered SVGs from the preview DOM (passed via options.mermaidSvgs)
+  // instead of calling mermaid.render() which can hang or fail in the export context.
+
+  let mermaidBlockIndex = 0;
+
+  function mermaidFallbackParagraph(code: string): Paragraph {
+    try {
+      const codeHighlightRuns = codeHighlighter.getHighlightedRunsForCode(code, 'mermaid');
+      return new Paragraph({
+        children: codeHighlightRuns,
+        wordWrap: true,
+        alignment: AlignmentType.LEFT,
+        spacing: { before: 200, after: 200 },
+        shading: { fill: themeStyles.characterStyles?.code?.background || 'F6F8FA' },
+        border: {
+          top: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+          bottom: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+          left: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+          right: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+        },
+      });
+    } catch {
+      return new Paragraph({
+        children: [new TextRun({ text: code, font: 'Consolas', size: 20 })],
+        spacing: { before: 200, after: 200 },
+      });
+    }
+  }
+
+  async function convertMermaidBlock(code: string): Promise<Paragraph> {
+    const svgString = options.mermaidSvgs?.[mermaidBlockIndex] ?? null;
+    mermaidBlockIndex++;
+
+    if (!svgString) {
+      return mermaidFallbackParagraph(code);
+    }
+
+    try {
+      const pngBuffer = await svgToPngBuffer(svgString);
+      if (!pngBuffer || pngBuffer.length === 0) {
+        throw new Error('Empty PNG buffer from SVG conversion');
+      }
+
+      const { width: origW, height: origH } = await getImageDimensionsFromBuffer(pngBuffer);
+      if (origW === 0 || origH === 0) {
+        throw new Error('Zero dimensions from mermaid PNG');
+      }
+
+      const displayW = Math.round(origW / 4);
+      const displayH = Math.round(origH / 4);
+      const { width, height } = calculateImageDimensions(displayW, displayH);
+
+      return new Paragraph({
+        children: [
+          new ImageRun({
+            data: pngBuffer,
+            transformation: { width: width || 100, height: height || 100 },
+            type: 'png',
+            altText: {
+              title: 'Mermaid Diagram',
+              description: code.slice(0, 100),
+              name: 'mermaid-diagram',
+            },
+          }),
+        ],
+        alignment: AlignmentType.CENTER,
+        spacing: { before: 200, after: 200 },
+      });
+    } catch (error) {
+      console.warn('[DOCX] Mermaid SVG-to-PNG failed:', error);
+      return mermaidFallbackParagraph(code);
+    }
+  }
+
+  function svgToPngBuffer(svgString: string): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new Error('SVG to PNG conversion timed out'));
+      }, 10000);
+
+      const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+      const url = URL.createObjectURL(svgBlob);
+      const img = new Image();
+
+      img.onload = () => {
+        URL.revokeObjectURL(url);
+        try {
+          const scale = 2;
+          const canvas = document.createElement('canvas');
+          canvas.width = img.width * scale;
+          canvas.height = img.height * scale;
+          const ctx = canvas.getContext('2d')!;
+          ctx.scale(scale, scale);
+          ctx.drawImage(img, 0, 0);
+
+          canvas.toBlob((blob) => {
+            clearTimeout(timeoutId);
+            if (!blob) { reject(new Error('Canvas toBlob failed')); return; }
+            blob.arrayBuffer().then(ab => resolve(new Uint8Array(ab))).catch(reject);
+          }, 'image/png');
+        } catch (err) {
+          clearTimeout(timeoutId);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      };
+
+      img.onerror = () => {
+        clearTimeout(timeoutId);
+        URL.revokeObjectURL(url);
+        reject(new Error('Failed to load SVG for Mermaid rendering'));
+      };
+
+      img.src = url;
+    });
+  }
+
+  function getImageDimensionsFromBuffer(buffer: Uint8Array): Promise<{ width: number; height: number }> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new Error('Image dimension read timed out'));
+      }, 5000);
+
+      const blob = new Blob([buffer as BlobPart], { type: 'image/png' });
+      const url = URL.createObjectURL(blob);
+      const img = new Image();
+
+      img.onload = () => {
+        clearTimeout(timeoutId);
+        URL.revokeObjectURL(url);
+        resolve({ width: img.width, height: img.height });
+      };
+
+      img.onerror = () => {
+        clearTimeout(timeoutId);
+        URL.revokeObjectURL(url);
+        reject(new Error('Failed to read image dimensions'));
+      };
+
+      img.src = url;
+    });
+  }
+
   // ---- Recursive node converter ----
 
   async function convertNode(
@@ -241,6 +414,11 @@ export async function exportMarkdownToDocx(
     listLevel = 0,
     blockquoteNestLevel = 0
   ): Promise<FileChild | FileChild[] | null> {
+    // Mermaid code blocks → render as image
+    if (node.type === 'code' && node.lang === 'mermaid') {
+      return await convertMermaidBlock(node.value ?? '');
+    }
+
     switch (node.type) {
       case 'heading':
         return await convertHeading(node);

--- a/markdown-sheet/src/lib/docx/docx-exporter.ts
+++ b/markdown-sheet/src/lib/docx/docx-exporter.ts
@@ -1,0 +1,429 @@
+/**
+ * DOCX Exporter for markdown-sheet (Tauri)
+ * Simplified async function version of the original class-based exporter.
+ * No plugin system, no globalThis.platform dependencies.
+ */
+
+import {
+  Document,
+  Packer,
+  Paragraph,
+  TextRun,
+  HeadingLevel,
+  AlignmentType,
+  BorderStyle,
+  convertInchesToTwip,
+  type FileChild,
+  type ParagraphChild,
+  type IStylesOptions,
+  type IBaseParagraphStyleOptions,
+  type IDocumentDefaultsOptions,
+  type IParagraphStylePropertiesOptions,
+} from 'docx';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import { visit } from 'unist-util-visit';
+import { loadThemeForDOCX } from './theme-loader';
+import { mathJaxReady, convertLatex2Math } from './docx-math-converter';
+import { createCodeHighlighter, type CodeHighlighter } from './docx-code-highlighter';
+import { createTableConverter, type TableConverter } from './docx-table-converter';
+import { createBlockquoteConverter, type BlockquoteConverter } from './docx-blockquote-converter';
+import { createListConverter, createNumberingLevels, type ListConverter } from './docx-list-converter';
+import { createInlineConverter, type InlineConverter, type InlineNode } from './docx-inline-converter';
+import type {
+  DOCXThemeStyles,
+  DOCXHeadingStyle,
+  DOCXASTNode,
+  DOCXListNode,
+  DOCXBlockquoteNode,
+  DOCXTableNode,
+  LinkDefinition,
+  ImageBufferResult,
+} from './types';
+
+// ============================================================================
+// Options
+// ============================================================================
+
+export interface ExportDocxOptions {
+  /** Base directory for resolving relative image paths */
+  baseDir?: string;
+}
+
+// ============================================================================
+// Image fetching
+// ============================================================================
+
+const imageCache = new Map<string, ImageBufferResult>();
+
+function guessContentType(url: string): string {
+  const ext = url.split('.').pop()?.toLowerCase().split('?')[0] || '';
+  const map: Record<string, string> = {
+    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
+    gif: 'image/gif', bmp: 'image/bmp', webp: 'image/webp', svg: 'image/svg+xml',
+  };
+  return map[ext] || 'image/png';
+}
+
+async function fetchImageAsBuffer(url: string, baseDir?: string): Promise<ImageBufferResult> {
+  if (imageCache.has(url)) return imageCache.get(url)!;
+
+  // data: URL
+  if (url.startsWith('data:')) {
+    const match = url.match(/^data:([^;,]+)[^,]*,(.+)$/);
+    if (!match) throw new Error('Invalid data URL format');
+    const contentType = match[1];
+    const binaryString = atob(match[2]);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
+    const result: ImageBufferResult = { buffer: bytes, contentType };
+    imageCache.set(url, result);
+    return result;
+  }
+
+  const isNetworkUrl = url.startsWith('http://') || url.startsWith('https://');
+
+  if (isNetworkUrl) {
+    const resp = await fetch(url);
+    const ab = await resp.arrayBuffer();
+    const contentType = resp.headers.get('content-type') || guessContentType(url);
+    const result: ImageBufferResult = { buffer: new Uint8Array(ab), contentType };
+    imageCache.set(url, result);
+    return result;
+  }
+
+  // Local file — use Tauri plugin-fs readFile
+  try {
+    const { readFile } = await import('@tauri-apps/plugin-fs');
+    let resolvedPath = url;
+    // Resolve relative path against baseDir
+    if (baseDir && !url.startsWith('/') && !url.match(/^[A-Za-z]:\\/)) {
+      resolvedPath = baseDir.replace(/\\/g, '/').replace(/\/[^/]*$/, '') + '/' + url;
+    }
+    const bytes = await readFile(resolvedPath);
+    const contentType = guessContentType(url);
+    const result: ImageBufferResult = { buffer: bytes, contentType };
+    imageCache.set(url, result);
+    return result;
+  } catch (error) {
+    throw new Error(`Failed to read local image: ${url} - ${(error as Error).message}`);
+  }
+}
+
+// ============================================================================
+// Markdown parsing
+// ============================================================================
+
+function parseMarkdown(markdown: string): { ast: DOCXASTNode; linkDefinitions: Map<string, LinkDefinition> } {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm, { singleTilde: false })
+    .use(remarkMath);
+
+  const ast = processor.parse(markdown);
+  const transformed = processor.runSync(ast);
+
+  const linkDefinitions = new Map<string, LinkDefinition>();
+  visit(transformed, 'definition', (node) => {
+    const defNode = node as { identifier?: string; url?: string; title?: string };
+    if (defNode.identifier) {
+      linkDefinitions.set(defNode.identifier.toLowerCase(), {
+        url: defNode.url || '',
+        title: defNode.title ?? null,
+      });
+    }
+  });
+
+  return { ast: transformed as DOCXASTNode, linkDefinitions };
+}
+
+// ============================================================================
+// Alignment helper
+// ============================================================================
+
+function toAlignmentType(alignment?: string): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
+  if (!alignment) return undefined;
+  const map: Record<string, (typeof AlignmentType)[keyof typeof AlignmentType]> = {
+    left: AlignmentType.LEFT, center: AlignmentType.CENTER,
+    right: AlignmentType.RIGHT, justify: AlignmentType.JUSTIFIED,
+  };
+  return map[alignment.trim().toLowerCase()];
+}
+
+function toDocumentDefaults(defaults: DOCXThemeStyles['default']): IDocumentDefaultsOptions {
+  return {
+    run: defaults.run,
+    paragraph: defaults.paragraph
+      ? { spacing: defaults.paragraph.spacing, alignment: toAlignmentType(defaults.paragraph.alignment) }
+      : undefined,
+  };
+}
+
+function toHeadingStyle(style: DOCXHeadingStyle): IBaseParagraphStyleOptions {
+  return {
+    name: style.name,
+    basedOn: style.basedOn,
+    next: style.next,
+    run: style.run,
+    paragraph: {
+      spacing: style.paragraph.spacing,
+      alignment: toAlignmentType(style.paragraph.alignment),
+    },
+  };
+}
+
+// ============================================================================
+// Main export function
+// ============================================================================
+
+/**
+ * Export Markdown content to DOCX format
+ * @param markdown - Markdown source text
+ * @param options - Export options
+ * @returns Uint8Array of the DOCX file
+ */
+export async function exportMarkdownToDocx(
+  markdown: string,
+  options: ExportDocxOptions = {}
+): Promise<Uint8Array> {
+  // Load theme
+  const themeStyles = await loadThemeForDOCX('default');
+
+  // Initialize MathJax
+  await mathJaxReady();
+
+  // Parse markdown
+  const { ast, linkDefinitions } = parseMarkdown(markdown);
+
+  // Create code highlighter
+  const codeHighlighter = createCodeHighlighter(themeStyles);
+
+  // Mutable counters
+  let listInstanceCounter = 0;
+
+  // Create converters
+  const inlineConverter = createInlineConverter({
+    themeStyles,
+    fetchImageAsBuffer: (url: string) => fetchImageAsBuffer(url, options.baseDir),
+    reportResourceProgress: () => {},
+    linkDefinitions,
+    renderer: null,
+    emojiStyle: 'system',
+    linkColor: themeStyles.linkColor,
+  });
+
+  const tableConverter = createTableConverter({
+    themeStyles,
+    convertInlineNodes: (nodes, style) => inlineConverter.convertInlineNodes(nodes, style),
+    mergeEmptyCells: true,
+    tableLayout: 'center',
+  });
+
+  const blockquoteConverter = createBlockquoteConverter({
+    themeStyles,
+    convertInlineNodes: (nodes, style) => inlineConverter.convertInlineNodes(nodes, style),
+  });
+
+  const listConverter = createListConverter({
+    themeStyles,
+    convertInlineNodes: (nodes, style) => inlineConverter.convertInlineNodes(nodes, style),
+    getListInstanceCounter: () => listInstanceCounter,
+    incrementListInstanceCounter: () => listInstanceCounter++,
+  });
+
+  // ---- Recursive node converter ----
+
+  async function convertNode(
+    node: DOCXASTNode,
+    parentStyle: Record<string, unknown> = {},
+    listLevel = 0,
+    blockquoteNestLevel = 0
+  ): Promise<FileChild | FileChild[] | null> {
+    switch (node.type) {
+      case 'heading':
+        return await convertHeading(node);
+      case 'paragraph':
+        return await convertParagraph(node, parentStyle);
+      case 'list':
+        return await listConverter.convertList(node as unknown as DOCXListNode);
+      case 'code':
+        return convertCodeBlock(node, listLevel, blockquoteNestLevel);
+      case 'blockquote':
+        return await blockquoteConverter.convertBlockquote(node as unknown as DOCXBlockquoteNode, listLevel);
+      case 'table':
+        return await tableConverter.convertTable(node as unknown as DOCXTableNode, listLevel);
+      case 'thematicBreak':
+        return convertThematicBreak();
+      case 'html':
+        return convertHtml();
+      case 'math':
+        return convertMathBlock(node);
+      default:
+        return null;
+    }
+  }
+
+  // Wire up circular dependencies
+  blockquoteConverter.setConvertChildNode((node, bqNest) => convertNode(node, {}, 0, bqNest));
+  listConverter.setConvertChildNode((node, ll) => convertNode(node, {}, ll));
+
+  // ---- Node converters ----
+
+  async function convertHeading(node: DOCXASTNode): Promise<Paragraph> {
+    const levels: Record<number, (typeof HeadingLevel)[keyof typeof HeadingLevel]> = {
+      1: HeadingLevel.HEADING_1, 2: HeadingLevel.HEADING_2,
+      3: HeadingLevel.HEADING_3, 4: HeadingLevel.HEADING_4,
+      5: HeadingLevel.HEADING_5, 6: HeadingLevel.HEADING_6,
+    };
+    const depth = node.depth || 1;
+    const headingStyle = themeStyles.paragraphStyles?.[`heading${depth}`];
+    const children = await inlineConverter.convertInlineNodes(
+      (node.children || []) as unknown as InlineNode[], {}
+    );
+    const config: {
+      children?: ParagraphChild[]; text?: string;
+      heading: (typeof HeadingLevel)[keyof typeof HeadingLevel];
+      alignment?: (typeof AlignmentType)[keyof typeof AlignmentType];
+    } = { heading: levels[depth] || HeadingLevel.HEADING_1 };
+    if (children.length > 0) config.children = children;
+    else config.text = '';
+    if (headingStyle?.paragraph?.alignment === 'center') config.alignment = AlignmentType.CENTER;
+    return new Paragraph(config);
+  }
+
+  async function convertParagraph(node: DOCXASTNode, parentStyle: Record<string, unknown>): Promise<Paragraph> {
+    const children = await inlineConverter.convertInlineNodes(
+      (node.children || []) as unknown as InlineNode[], parentStyle
+    );
+    const spacing = themeStyles.default?.paragraph?.spacing || { before: 0, after: 200, line: 276 };
+    return new Paragraph({
+      children: children.length > 0 ? children : undefined,
+      text: children.length === 0 ? '' : undefined,
+      spacing: { before: spacing.before, after: spacing.after, line: spacing.line },
+      alignment: AlignmentType.LEFT,
+    });
+  }
+
+  function convertCodeBlock(node: DOCXASTNode, listLevel = 0, blockquoteNestLevel = 0): Paragraph {
+    const runs = codeHighlighter.getHighlightedRunsForCode(node.value ?? '', node.lang);
+    const codeBackground = themeStyles.characterStyles?.code?.background || 'F6F8FA';
+    const borderSpace = 200;
+    const baseIndent = listLevel > 0 ? convertInchesToTwip(0.5 * listLevel) : 0;
+    const indentLeft = baseIndent + borderSpace;
+    const blockquoteCompensation = blockquoteNestLevel > 0 ? 300 * blockquoteNestLevel : 0;
+    const indentRight = borderSpace + blockquoteCompensation;
+    return new Paragraph({
+      children: runs,
+      wordWrap: true,
+      alignment: AlignmentType.LEFT,
+      spacing: { before: 200, after: 200, line: 276 },
+      shading: { fill: codeBackground },
+      indent: { left: indentLeft, right: indentRight },
+      border: {
+        top: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+        bottom: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+        left: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+        right: { color: 'E1E4E8', space: 10, style: BorderStyle.SINGLE, size: 6 },
+      },
+    });
+  }
+
+  function convertHtml(): Paragraph {
+    return new Paragraph({
+      children: [new TextRun({ text: '[HTML Content]', italics: true, color: '666666' })],
+      alignment: AlignmentType.LEFT,
+      spacing: { before: 120, after: 120 },
+    });
+  }
+
+  function convertThematicBreak(): Paragraph {
+    const spacing = themeStyles.default?.paragraph?.spacing || { before: 0, after: 200, line: 276 };
+    return new Paragraph({
+      text: '',
+      alignment: AlignmentType.LEFT,
+      spacing: { before: spacing.before, after: spacing.after, line: spacing.line },
+    });
+  }
+
+  function convertMathBlock(node: DOCXASTNode): Paragraph {
+    try {
+      const math = convertLatex2Math(node.value || '');
+      return new Paragraph({
+        children: [math],
+        spacing: { before: 120, after: 120 },
+        alignment: AlignmentType.CENTER,
+      });
+    } catch (error) {
+      console.warn('Math conversion error:', error);
+      const codeStyle = themeStyles.characterStyles?.code || { font: 'Consolas', size: 20 };
+      return new Paragraph({
+        children: [new TextRun({ text: node.value || '', font: codeStyle.font, size: codeStyle.size })],
+        alignment: AlignmentType.LEFT,
+        spacing: { before: 120, after: 120 },
+      });
+    }
+  }
+
+  // ---- Build document ----
+
+  const elements: FileChild[] = [];
+  let lastNodeType: string | null = null;
+
+  if (ast.children) {
+    for (const node of ast.children) {
+      // Spacing between consecutive tables / blockquotes
+      if (node.type === 'table' && lastNodeType === 'table') {
+        elements.push(new Paragraph({ text: '', spacing: { before: 120, after: 120, line: 240 } }));
+      }
+      if (node.type === 'blockquote' && lastNodeType === 'blockquote') {
+        elements.push(new Paragraph({ text: '', spacing: { before: 120, after: 120, line: 240 } }));
+      }
+
+      const converted = await convertNode(node);
+      if (converted) {
+        if (Array.isArray(converted)) elements.push(...converted);
+        else elements.push(converted);
+      }
+      lastNodeType = node.type;
+    }
+  }
+
+  // Styles
+  const paragraphStyles = Object.entries(themeStyles.paragraphStyles).map(([id, style]) => ({
+    id,
+    ...toHeadingStyle(style),
+  }));
+
+  const styles: IStylesOptions = {
+    default: { document: toDocumentDefaults(themeStyles.default) },
+    paragraphStyles,
+  };
+
+  const doc = new Document({
+    creator: 'Markdown Sheet',
+    lastModifiedBy: 'Markdown Sheet',
+    numbering: {
+      config: [{ reference: 'default-ordered-list', levels: createNumberingLevels() }],
+    },
+    styles,
+    sections: [{
+      properties: {
+        page: {
+          margin: {
+            top: convertInchesToTwip(1), right: convertInchesToTwip(1),
+            bottom: convertInchesToTwip(1), left: convertInchesToTwip(1),
+          },
+        },
+      },
+      children: elements,
+    }],
+  });
+
+  // Pack to Uint8Array
+  const blob = await Packer.toBlob(doc);
+  const arrayBuffer = await blob.arrayBuffer();
+  imageCache.clear();
+  return new Uint8Array(arrayBuffer);
+}

--- a/markdown-sheet/src/lib/docx/docx-image-utils.ts
+++ b/markdown-sheet/src/lib/docx/docx-image-utils.ts
@@ -1,0 +1,186 @@
+// DOCX Image Utilities
+// Functions for handling images in DOCX export
+
+import {
+  ImageRun,
+} from 'docx';
+import type {
+  ImageBufferResult,
+  DOCXImageType,
+} from './types';
+
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+interface Renderer {
+  render(type: string, content: string, options?: Record<string, unknown>): Promise<{
+    base64: string;
+    width: number;
+    height: number;
+  }>;
+}
+
+type FetchImageAsBufferFunction = (url: string) => Promise<ImageBufferResult>;
+
+/**
+ * Calculate appropriate image dimensions for DOCX to fit within page constraints
+ * Maximum width: 6 inches (page width with 1 inch margins on letter size)
+ * Maximum height: 9.5 inches (page height with 1 inch margins on letter size)
+ * @param originalWidth - Original image width in pixels
+ * @param originalHeight - Original image height in pixels
+ * @returns {width: number, height: number} in pixels
+ */
+export function calculateImageDimensions(originalWidth: number, originalHeight: number): ImageDimensions {
+  const maxWidthInches = 6;    // 8.5 - 1 - 1 = 6.5, use 6 for safety
+  const maxHeightInches = 9.5; // 11 - 1 - 1 = 9, use 9.5 to maximize vertical space
+  const maxWidthPixels = maxWidthInches * 96;  // 96 DPI = 576 pixels
+  const maxHeightPixels = maxHeightInches * 96; // 96 DPI = 912 pixels
+
+  // If image is smaller than both max width and height, use original size
+  if (originalWidth <= maxWidthPixels && originalHeight <= maxHeightPixels) {
+    return { width: originalWidth, height: originalHeight };
+  }
+
+  // Calculate scaling ratios for both dimensions
+  const widthRatio = maxWidthPixels / originalWidth;
+  const heightRatio = maxHeightPixels / originalHeight;
+
+  // Use the smaller ratio to ensure the image fits within both constraints
+  const ratio = Math.min(widthRatio, heightRatio);
+
+  return {
+    width: Math.round(originalWidth * ratio),
+    height: Math.round(originalHeight * ratio)
+  };
+}
+
+/**
+ * Get image dimensions from buffer
+ * @param buffer - Image buffer
+ * @param contentType - Image content type
+ * @returns Promise with width and height
+ */
+export async function getImageDimensions(buffer: Uint8Array, contentType: string): Promise<ImageDimensions> {
+  return new Promise((resolve, reject) => {
+    const safeArrayBuffer = buffer.slice().buffer;
+    const blob = new Blob([safeArrayBuffer], { type: contentType });
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve({ width: img.width, height: img.height });
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to load image'));
+    };
+
+    img.src = url;
+  });
+}
+
+/**
+ * Determine image type from content type or URL
+ * @param contentType - Image content type
+ * @param url - Image URL
+ * @returns Image type for docx
+ */
+export function determineImageType(contentType: string | null, url: string): DOCXImageType {
+  let imageType: DOCXImageType = 'png'; // default
+
+  if (contentType) {
+    if (contentType.includes('jpeg') || contentType.includes('jpg')) {
+      imageType = 'jpg';
+    } else if (contentType.includes('png')) {
+      imageType = 'png';
+    } else if (contentType.includes('gif')) {
+      imageType = 'gif';
+    } else if (contentType.includes('bmp')) {
+      imageType = 'bmp';
+    }
+  } else if (url) {
+    // Fallback: determine from URL extension
+    const ext = url.toLowerCase().split('.').pop()?.split('?')[0] || '';
+    const extMap: Record<string, DOCXImageType> = {
+      'jpg': 'jpg',
+      'jpeg': 'jpg',
+      'png': 'png',
+      'gif': 'gif',
+      'bmp': 'bmp',
+    };
+    if (ext in extMap) {
+      imageType = extMap[ext];
+    }
+  }
+
+  return imageType;
+}
+
+/**
+ * Check if URL or content type indicates an SVG image
+ * @param url - Image URL
+ * @param contentType - Content type (optional)
+ * @returns True if SVG
+ */
+export function isSvgImage(url: string, contentType: string | null = null): boolean {
+  if (contentType && contentType.includes('svg')) {
+    return true;
+  }
+  const lowerUrl = url.toLowerCase();
+  return lowerUrl.endsWith('.svg') || lowerUrl.includes('image/svg+xml');
+}
+
+/**
+ * Convert SVG content to PNG using renderer
+ * @param svgContent - SVG content string
+ * @param renderer - Renderer instance with render() method
+ * @returns Promise with buffer, width, and height
+ */
+export async function convertSvgToPng(svgContent: string, renderer: Renderer): Promise<{ buffer: Uint8Array; width: number; height: number }> {
+  // Render SVG to PNG
+  const pngResult = await renderer.render('svg', svgContent, { outputFormat: 'png' });
+
+  // Convert base64 to Uint8Array
+  const binaryString = atob(pngResult.base64);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  return {
+    buffer: bytes,
+    width: pngResult.width,
+    height: pngResult.height
+  };
+}
+
+/**
+ * Get SVG content from URL or data URL
+ * @param url - SVG URL or data URL
+ * @param fetchImageAsBuffer - Function to fetch image as buffer
+ * @returns SVG content string
+ */
+export async function getSvgContent(url: string, fetchImageAsBuffer: FetchImageAsBufferFunction): Promise<string> {
+  // Handle data: URLs
+  if (url.startsWith('data:image/svg+xml')) {
+    const base64Match = url.match(/^data:image\/svg\+xml;base64,(.+)$/);
+    if (base64Match) {
+      return atob(base64Match[1]);
+    }
+    // Try URL encoded format
+    const urlMatch = url.match(/^data:image\/svg\+xml[;,](.+)$/);
+    if (urlMatch) {
+      return decodeURIComponent(urlMatch[1]);
+    }
+    throw new Error('Unsupported SVG data URL format');
+  }
+
+  // Fetch SVG file (local or remote)
+  const { buffer } = await fetchImageAsBuffer(url);
+  return new TextDecoder().decode(buffer);
+}

--- a/markdown-sheet/src/lib/docx/docx-inline-converter.ts
+++ b/markdown-sheet/src/lib/docx/docx-inline-converter.ts
@@ -1,0 +1,663 @@
+/**
+ * Inline node conversion for DOCX export
+ */
+
+import {
+  TextRun,
+  ImageRun,
+  ExternalHyperlink,
+  type IRunOptions,
+  type ParagraphChild
+} from 'docx';
+import { convertLatex2Math } from './docx-math-converter';
+import {
+  calculateImageDimensions,
+  getImageDimensions,
+  determineImageType,
+  isSvgImage,
+  convertSvgToPng,
+  getSvgContent,
+} from './docx-image-utils';
+import type {
+  DOCXThemeStyles,
+  LinkDefinition,
+  ImageBufferResult,
+  DOCXImageType,
+  EmojiStyle,
+} from './types';
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Renderer interface for SVG conversion
+ */
+interface Renderer {
+  render(type: string, content: string, options?: object): Promise<{
+    base64: string;
+    width: number;
+    height: number;
+    format: string;
+  }>;
+}
+
+/**
+ * Options for creating inline converter
+ */
+interface InlineConverterOptions {
+  themeStyles: DOCXThemeStyles;
+  fetchImageAsBuffer: (url: string) => Promise<ImageBufferResult>;
+  reportResourceProgress: () => void;
+  linkDefinitions?: Map<string, LinkDefinition>;
+  renderer?: Renderer | null;
+  emojiStyle?: EmojiStyle;
+  linkColor?: string;  // Link color from colorScheme (hex without #)
+}
+
+/**
+ * Parent style for inline elements
+ */
+interface ParentStyle extends Partial<IRunOptions> {
+  size?: number;
+  bold?: boolean;
+  italics?: boolean;
+  strike?: boolean;
+}
+
+/**
+ * AST Node types
+ */
+interface BaseNode {
+  type: string;
+}
+
+interface TextNode extends BaseNode {
+  type: 'text';
+  value: string;
+}
+
+interface StrongNode extends BaseNode {
+  type: 'strong';
+  children: InlineNode[];
+}
+
+interface EmphasisNode extends BaseNode {
+  type: 'emphasis';
+  children: InlineNode[];
+}
+
+interface DeleteNode extends BaseNode {
+  type: 'delete';
+  children: InlineNode[];
+}
+
+interface InlineCodeNode extends BaseNode {
+  type: 'inlineCode';
+  value: string;
+}
+
+interface LinkNode extends BaseNode {
+  type: 'link';
+  url: string;
+  title?: string;
+  children: InlineNode[];
+}
+
+interface LinkReferenceNode extends BaseNode {
+  type: 'linkReference';
+  identifier: string;
+  children: InlineNode[];
+}
+
+interface ImageNode extends BaseNode {
+  type: 'image';
+  url: string;
+  alt?: string;
+  title?: string;
+}
+
+interface InlineMathNode extends BaseNode {
+  type: 'inlineMath';
+  value: string;
+}
+
+interface BreakNode extends BaseNode {
+  type: 'break';
+}
+
+interface HtmlNode extends BaseNode {
+  type: 'html';
+  value?: string;
+}
+
+interface SuperscriptNode extends BaseNode {
+  type: 'superscript';
+  children: InlineNode[];
+}
+
+interface SubscriptNode extends BaseNode {
+  type: 'subscript';
+  children: InlineNode[];
+}
+
+export type InlineNode = 
+  | TextNode 
+  | StrongNode 
+  | EmphasisNode 
+  | DeleteNode 
+  | InlineCodeNode 
+  | LinkNode 
+  | LinkReferenceNode 
+  | ImageNode 
+  | InlineMathNode 
+  | BreakNode 
+  | HtmlNode
+  | SuperscriptNode
+  | SubscriptNode;
+
+/**
+ * Inline converter result type
+ */
+export type InlineResult = ParagraphChild;
+
+/**
+ * Inline converter interface
+ */
+export interface InlineConverter {
+  convertInlineNodes(nodes: InlineNode[], parentStyle?: ParentStyle): Promise<InlineResult[]>;
+  convertInlineNode(node: InlineNode, parentStyle?: ParentStyle): Promise<InlineResult | InlineResult[] | null>;
+  convertImage(node: ImageNode): Promise<ImageRun | TextRun>;
+  extractText(node: InlineNode | { type: string; children?: InlineNode[]; value?: string }): string;
+}
+
+// ============================================================================
+// Emoji Detection and Font Handling
+// ============================================================================
+
+/**
+ * Emoji font definitions for different styles
+ */
+const EMOJI_FONTS = {
+  /** Apple Color Emoji - iOS/macOS style (3D, glossy) */
+  apple: {
+    ascii: 'Apple Color Emoji',
+    eastAsia: 'Apple Color Emoji',
+    hAnsi: 'Apple Color Emoji',
+    cs: 'Apple Color Emoji',
+  },
+  /** Segoe UI Emoji - Windows style (flat design) */
+  windows: {
+    ascii: 'Segoe UI Emoji',
+    eastAsia: 'Segoe UI Emoji',
+    hAnsi: 'Segoe UI Emoji',
+    cs: 'Segoe UI Emoji',
+  },
+} as const;
+
+/**
+ * Get emoji font configuration based on style
+ * @param style - Emoji style preference
+ * @returns Font configuration for the specified style
+ */
+function getEmojiFont(style: EmojiStyle = 'windows') {
+  // 'system' style is handled separately, default to 'windows' for EMOJI_FONTS lookup
+  if (style === 'system') {
+    return EMOJI_FONTS.windows;
+  }
+  return EMOJI_FONTS[style];
+}
+
+/**
+ * Regex to match emoji characters
+ * Covers: emoticons, dingbats, symbols, flags, skin tone modifiers, ZWJ sequences, keycap emoji
+ * - \p{RI}\p{RI}: Regional Indicator pairs (flags like 🇺🇸)
+ * - [#*0-9]\u{FE0F}?\u{20E3}: Keycap emoji (#️⃣, 1️⃣, etc.)
+ * - \p{Extended_Pictographic}: Main emoji characters
+ * - \p{Emoji_Modifier}: Skin tone modifiers
+ * - \u{200D}: Zero-width joiner for compound emoji (👨‍👩‍👧‍👦)
+ */
+const EMOJI_REGEX = /(?:\p{RI}\p{RI}|[#*0-9]\u{FE0F}?\u{20E3}|\p{Extended_Pictographic}(?:\p{Emoji_Modifier}|\u{FE0F}|[\u{E0020}-\u{E007E}]+\u{E007F})?(?:\u{200D}(?:\p{Extended_Pictographic}(?:\p{Emoji_Modifier}|\u{FE0F}|[\u{E0020}-\u{E007E}]+\u{E007F})?|[#*0-9]\u{FE0F}?\u{20E3}))*)/gu;
+
+/**
+ * Split text into segments of regular text and emoji
+ * @param text - Input text
+ * @returns Array of segments with type ('text' or 'emoji') and content
+ */
+function splitTextByEmoji(text: string): Array<{ type: 'text' | 'emoji'; content: string }> {
+  const segments: Array<{ type: 'text' | 'emoji'; content: string }> = [];
+  let lastIndex = 0;
+
+  // Reset regex state
+  EMOJI_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = EMOJI_REGEX.exec(text)) !== null) {
+    // Add text before emoji (if any)
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
+    }
+    // Add emoji
+    segments.push({ type: 'emoji', content: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text (if any)
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', content: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/**
+ * Create an inline node converter
+ * @param options - Configuration options
+ * @returns Inline node converter
+ */
+export function createInlineConverter({ 
+  themeStyles, 
+  fetchImageAsBuffer, 
+  reportResourceProgress,
+  linkDefinitions,
+  renderer,
+  emojiStyle = 'system',
+  linkColor = '0366D6'  // Default to GitHub blue
+}: InlineConverterOptions): InlineConverter {
+  // Get emoji font based on user preference (null for system style)
+  const emojiFont = emojiStyle === 'system' ? null : getEmojiFont(emojiStyle);
+  
+  /**
+   * Remove Variation Selector (U+FE0F) from emoji for better WPS compatibility
+   * WPS doesn't handle FE0F well, showing it as a box character
+   * @param emoji - Emoji string that may contain FE0F
+   * @returns Emoji string with FE0F removed
+   */
+  function stripVariationSelector(emoji: string): string {
+    return emoji.replace(/\uFE0F/g, '');
+  }
+
+  /**
+   * Convert text with emoji handling - split emoji into separate runs with emoji font
+   * @param text - Text content
+   * @param parentStyle - Parent style to apply
+   * @returns Single TextRun or array of TextRuns
+   */
+  function convertTextWithEmoji(text: string, parentStyle: ParentStyle): TextRun | TextRun[] {
+    // If system style, don't process emoji, return as-is
+    if (emojiFont === null) {
+      return new TextRun({ text: text, ...parentStyle });
+    }
+
+    const segments = splitTextByEmoji(text);
+    
+    // If no emoji found, return simple TextRun
+    if (segments.length === 1 && segments[0].type === 'text') {
+      return new TextRun({ text: text, ...parentStyle });
+    }
+    
+    // If only emoji (no regular text), return emoji TextRun(s)
+    if (segments.length === 1 && segments[0].type === 'emoji') {
+      const cleanEmoji = stripVariationSelector(text);
+      return new TextRun({ text: cleanEmoji, ...parentStyle, font: emojiFont });
+    }
+    
+    // Mixed content: create separate TextRuns for text and emoji
+    return segments.map(segment => {
+      if (segment.type === 'emoji') {
+        const cleanEmoji = stripVariationSelector(segment.content);
+        return new TextRun({ text: cleanEmoji, ...parentStyle, font: emojiFont });
+      }
+      return new TextRun({ text: segment.content, ...parentStyle });
+    });
+  }
+
+  /**
+   * Convert inline nodes (text, emphasis, strong, etc.)
+   * @param nodes - Array of inline AST nodes
+   * @param parentStyle - Parent style to inherit
+   * @returns Array of DOCX elements
+   */
+  async function convertInlineNodes(nodes: InlineNode[], parentStyle: ParentStyle = {}): Promise<InlineResult[]> {
+    const runs: InlineResult[] = [];
+    const bodyFont = themeStyles.default.run.font;
+    const bodySize = themeStyles.default.run.size;
+
+    const defaultStyle: ParentStyle = {
+      font: bodyFont,
+      size: bodySize,
+      ...parentStyle,
+    };
+
+    for (const node of nodes) {
+      const converted = await convertInlineNode(node, defaultStyle);
+      if (converted) {
+        if (Array.isArray(converted)) {
+          runs.push(...converted);
+        } else {
+          runs.push(converted);
+        }
+      }
+    }
+
+    return runs;
+  }
+
+  /**
+   * Convert single inline node
+   * @param node - Inline AST node
+   * @param parentStyle - Parent style to inherit
+   * @returns DOCX element(s) or null
+   */
+  async function convertInlineNode(node: InlineNode, parentStyle: ParentStyle = {}): Promise<InlineResult | InlineResult[] | null> {
+    console.log('[DOCX] convertInlineNode:', node.type);
+    switch (node.type) {
+      case 'text':
+        return convertTextWithEmoji(node.value, parentStyle);
+
+      case 'strong':
+        return await convertInlineNodes(node.children, { ...parentStyle, bold: true });
+
+      case 'emphasis':
+        return await convertInlineNodes(node.children, { ...parentStyle, italics: true });
+
+      case 'delete':
+        return await convertInlineNodes(node.children, { ...parentStyle, strike: true });
+
+      case 'superscript':
+        return await convertInlineNodes(node.children, { ...parentStyle, superScript: true });
+
+      case 'subscript':
+        return await convertInlineNodes(node.children, { ...parentStyle, subScript: true });
+
+      case 'inlineCode': {
+        const codeStyle = themeStyles.characterStyles.code;
+        return new TextRun({
+          ...parentStyle,
+          text: node.value,
+          font: codeStyle.font,
+          size: codeStyle.size,
+          shading: { fill: codeStyle.background },
+        });
+      }
+
+      case 'link':
+        return await convertLink(node, parentStyle);
+
+      case 'linkReference':
+        return await convertLinkReference(node, parentStyle);
+
+      case 'image':
+        return await convertImage(node);
+
+      case 'inlineMath':
+        return await convertInlineMath(node, parentStyle);
+
+      case 'break':
+        return new TextRun({ text: '', break: 1 });
+
+      case 'html': {
+        const htmlValue = node.value?.trim() || '';
+        if (/^<br\s*\/?>$/i.test(htmlValue)) {
+          return new TextRun({ text: '', break: 1 });
+        }
+        const textContent = htmlValue.replace(/<[^>]+>/g, '');
+        return convertTextWithEmoji(textContent, parentStyle);
+      }
+
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Convert link node
+   * @param node - Link AST node
+   * @param parentStyle - Parent style
+   * @returns DOCX ExternalHyperlink
+   */
+  async function convertLink(node: LinkNode, parentStyle: ParentStyle): Promise<ExternalHyperlink | ImageRun | TextRun> {
+    const url = node.url || '#';
+
+    // Check if link contains an image (e.g., [![alt](img-url)](link-url))
+    const imageChild = node.children?.find((child: InlineNode) => child.type === 'image') as ImageNode | undefined;
+    if (imageChild) {
+      // For image links, just render the image (DOCX doesn't support clickable images well)
+      console.log('[DOCX] Link contains image, converting image child:', imageChild.url);
+      return await convertImage(imageChild);
+    }
+
+    const text = extractText(node);
+
+    const linkStyle = {
+      style: 'Hyperlink' as const,
+      color: linkColor,
+      underline: { type: 'single' as const, color: linkColor },
+      ...parentStyle,
+    };
+
+    // Handle emoji in link text
+    const textRuns = convertTextWithEmoji(text, linkStyle);
+
+    return new ExternalHyperlink({
+      children: Array.isArray(textRuns) ? textRuns : [textRuns],
+      link: url,
+    });
+  }
+
+  /**
+   * Convert link reference node
+   * @param node - LinkReference AST node
+   * @param parentStyle - Parent style
+   * @returns DOCX ExternalHyperlink
+   */
+  async function convertLinkReference(node: LinkReferenceNode, parentStyle: ParentStyle): Promise<ExternalHyperlink> {
+    const text = extractText(node);
+    const identifier = node.identifier.toLowerCase();
+    const definition = linkDefinitions?.get(identifier);
+    const url = definition?.url || '#';
+
+    const linkStyle = {
+      style: 'Hyperlink' as const,
+      color: linkColor,
+      underline: { type: 'single' as const, color: linkColor },
+      ...parentStyle,
+    };
+
+    // Handle emoji in link text
+    const textRuns = convertTextWithEmoji(text, linkStyle);
+
+    return new ExternalHyperlink({
+      children: Array.isArray(textRuns) ? textRuns : [textRuns],
+      link: url,
+    });
+  }
+
+  /**
+   * Convert image node
+   * @param node - Image AST node
+   * @returns DOCX ImageRun or error TextRun
+   */
+  async function convertImage(node: ImageNode): Promise<ImageRun | TextRun> {
+    console.log('[DOCX] convertImage called:', { url: node.url, alt: node.alt });
+    try {
+      // Check if image is SVG (by URL)
+      const isSvg = isSvgImage(node.url);
+      console.log('[DOCX] isSvgImage check:', { url: node.url, isSvg });
+      if (isSvg) {
+        return await convertSvgImageFromUrl(node.url, node.alt);
+      }
+
+      // Fetch image as buffer
+      console.log('[DOCX] Fetching image as buffer:', node.url);
+      const { buffer, contentType } = await fetchImageAsBuffer(node.url);
+      console.log('[DOCX] Fetched image:', { url: node.url, contentType, bufferLength: buffer.length });
+      
+      // Double-check content type to ensure it's not SVG
+      if (contentType && contentType.includes('svg')) {
+        console.log('[DOCX] Content type is SVG, converting:', contentType);
+        const svgContent = new TextDecoder().decode(buffer);
+        return await convertSvgImageContent(svgContent, node.alt);
+      }
+
+      const { width: originalWidth, height: originalHeight } = await getImageDimensions(buffer, contentType);
+      console.log('[DOCX] Image dimensions:', { originalWidth, originalHeight });
+      const { width: widthPx, height: heightPx } = calculateImageDimensions(originalWidth, originalHeight);
+      const imageType = determineImageType(contentType, node.url);
+      console.log('[DOCX] Creating ImageRun:', { widthPx, heightPx, imageType });
+
+      reportResourceProgress();
+
+      return new ImageRun({
+        data: buffer,
+        transformation: { width: widthPx, height: heightPx },
+        type: imageType,
+        altText: {
+          title: node.alt || 'Image',
+          description: node.alt || '',
+          name: node.alt || 'image',
+        },
+      });
+    } catch (error) {
+      console.warn('[DOCX] Failed to load image:', node.url, error);
+      reportResourceProgress();
+
+      return new TextRun({
+        text: `[图片加载失败: ${node.alt || node.url}]`,
+        italics: true,
+        color: 'DC2626',
+        bold: true,
+      });
+    }
+  }
+
+  /**
+   * Convert SVG image from URL by fetching and converting to PNG
+   * @param url - SVG image URL
+   * @param alt - Alt text
+   * @returns ImageRun or TextRun
+   */
+  async function convertSvgImageFromUrl(url: string, alt?: string): Promise<ImageRun | TextRun> {
+    console.log('[DOCX] convertSvgImageFromUrl called:', { url, alt });
+    try {
+      const svgContent = await getSvgContent(url, fetchImageAsBuffer);
+      console.log('[DOCX] Got SVG content, length:', svgContent.length);
+      return await convertSvgImageContent(svgContent, alt);
+    } catch (error) {
+      console.warn('[DOCX] Failed to load SVG image:', url, error);
+      reportResourceProgress();
+      return new TextRun({
+        text: `[SVG 图片加载失败: ${alt || url}]`,
+        italics: true,
+        color: 'DC2626',
+      });
+    }
+  }
+
+  /**
+   * Convert SVG content to PNG and create ImageRun
+   * @param svgContent - SVG content string
+   * @param alt - Alt text
+   * @returns ImageRun or TextRun
+   */
+  async function convertSvgImageContent(svgContent: string, alt?: string): Promise<ImageRun | TextRun> {
+    console.log('[DOCX] convertSvgImageContent called, renderer available:', !!renderer);
+    if (!renderer) {
+      reportResourceProgress();
+      return new TextRun({
+        text: '[SVG 图片 - 渲染器不可用]',
+        italics: true,
+        color: '666666',
+      });
+    }
+
+    try {
+      console.log('[DOCX] Calling convertSvgToPng...');
+      const { buffer, width, height } = await convertSvgToPng(svgContent, renderer);
+      console.log('[DOCX] SVG converted to PNG:', { bufferLength: buffer.length, width, height });
+      
+      // Calculate display size (1/4 of original PNG size)
+      const displayWidth = Math.round(width / 4);
+      const displayHeight = Math.round(height / 4);
+      
+      // Apply max-width constraint
+      const { width: constrainedWidth, height: constrainedHeight } = 
+        calculateImageDimensions(displayWidth, displayHeight);
+
+      reportResourceProgress();
+
+      return new ImageRun({
+        data: buffer,
+        transformation: {
+          width: constrainedWidth,
+          height: constrainedHeight,
+        },
+        type: 'png',
+        altText: {
+          title: alt || 'SVG Image',
+          description: alt || 'SVG image',
+          name: alt || 'svg-image',
+        },
+      });
+    } catch (error) {
+      console.warn('Failed to render SVG:', error);
+      reportResourceProgress();
+      return new TextRun({
+        text: `[SVG 渲染失败: ${(error as Error).message}]`,
+        italics: true,
+        color: 'FF0000',
+      });
+    }
+  }
+
+  /**
+   * Convert inline math node
+   * @param node - InlineMath AST node
+   * @param parentStyle - Parent style
+   * @returns DOCX Math or fallback TextRun
+   */
+  async function convertInlineMath(node: InlineMathNode, parentStyle: ParentStyle): Promise<InlineResult> {
+    try {
+      return convertLatex2Math(node.value);
+    } catch (error) {
+      console.warn('Inline math conversion error:', error);
+      const codeStyle = themeStyles.characterStyles.code;
+      return new TextRun({
+        text: node.value,
+        font: codeStyle.font,
+        size: codeStyle.size,
+        ...parentStyle,
+      });
+    }
+  }
+
+  /**
+   * Extract plain text from node and its children
+   * @param node - AST node
+   * @returns Plain text content
+   */
+  function extractText(node: InlineNode): string {
+    if ('value' in node && node.value) {
+      return node.value;
+    }
+    if ('children' in node && node.children) {
+      let text = '';
+      for (const child of node.children) {
+        text += extractText(child);
+      }
+      return text;
+    }
+    return '';
+  }
+
+  return { 
+    convertInlineNodes, 
+    convertInlineNode,
+    convertImage,
+    extractText
+  };
+}

--- a/markdown-sheet/src/lib/docx/docx-list-converter.ts
+++ b/markdown-sheet/src/lib/docx/docx-list-converter.ts
@@ -1,0 +1,209 @@
+// List conversion for DOCX export
+
+import {
+  Paragraph,
+  TextRun,
+  AlignmentType,
+  convertInchesToTwip,
+  LevelFormat,
+  type IParagraphOptions,
+  type ParagraphChild,
+  type FileChild,
+} from 'docx';
+import type { DOCXThemeStyles, DOCXListNode, DOCXASTNode } from './types';
+import type { InlineResult, InlineNode } from './docx-inline-converter';
+
+// List item node within a DOCXListNode
+interface ListItemNode {
+  type: string;
+  checked?: boolean | null;
+  children: (InlineNode | DOCXListNode | { type: string; children?: InlineNode[] })[];
+}
+
+type ConvertInlineNodesFunction = (children: InlineNode[], options?: Record<string, unknown>) => Promise<InlineResult[]>;
+type ConvertChildNodeFunction = (node: DOCXASTNode, listLevel?: number) => Promise<FileChild | FileChild[] | null>;
+
+interface ListConverterOptions {
+  themeStyles: DOCXThemeStyles;
+  convertInlineNodes: ConvertInlineNodesFunction;
+  getListInstanceCounter: () => number;
+  incrementListInstanceCounter: () => number;
+}
+
+interface NumberingLevel {
+  level: number;
+  format: (typeof LevelFormat)[keyof typeof LevelFormat];
+  text: string;
+  alignment: typeof AlignmentType.START;
+  style: {
+    paragraph: {
+      indent: {
+        left: number;
+        hanging: number;
+      };
+    };
+  };
+}
+
+/**
+ * Create numbering levels configuration for ordered lists
+ * @returns Numbering levels configuration
+ */
+export function createNumberingLevels(): NumberingLevel[] {
+  const levels: NumberingLevel[] = [];
+  const formats: Array<(typeof LevelFormat)[keyof typeof LevelFormat]> = [
+    LevelFormat.DECIMAL,
+    LevelFormat.LOWER_ROMAN,
+    LevelFormat.LOWER_LETTER,
+    LevelFormat.LOWER_LETTER,
+    LevelFormat.LOWER_LETTER,
+    LevelFormat.LOWER_LETTER,
+    LevelFormat.LOWER_LETTER,
+    LevelFormat.LOWER_LETTER,
+    LevelFormat.LOWER_LETTER
+  ];
+  const baseIndent = 0.42;
+  const indentStep = 0.42;
+  const hanging = 0.28;
+
+  for (let i = 0; i < 9; i++) {
+    levels.push({
+      level: i,
+      format: formats[i],
+      text: `%${i + 1}.`,
+      alignment: AlignmentType.START,
+      style: {
+        paragraph: {
+          indent: {
+            left: convertInchesToTwip(baseIndent + i * indentStep),
+            hanging: convertInchesToTwip(i === 8 ? 0.30 : hanging)
+          },
+        },
+      },
+    });
+  }
+  return levels;
+}
+
+export interface ListConverter {
+  convertList(node: DOCXListNode): Promise<FileChild[]>;
+  convertListItem(ordered: boolean, item: ListItemNode, level: number, listInstance: number): Promise<FileChild[]>;
+  setConvertChildNode(fn: ConvertChildNodeFunction): void;
+}
+
+/**
+ * Create a list converter
+ * @param options - Configuration options
+ * @returns List converter
+ */
+export function createListConverter({ 
+  themeStyles, 
+  convertInlineNodes, 
+  getListInstanceCounter,
+  incrementListInstanceCounter
+}: ListConverterOptions): ListConverter {
+  // Default styles
+  const defaultRun = themeStyles.default?.run || { font: 'Arial', size: 22 };
+  const defaultSpacing = themeStyles.default?.paragraph?.spacing || { line: 276 };
+  
+  // Mutable reference to convertChildNode (set later to avoid circular dependency)
+  let convertChildNode: ConvertChildNodeFunction | undefined;
+
+  /**
+   * Set the convertChildNode function (called after all converters are initialized)
+   */
+  function setConvertChildNode(fn: ConvertChildNodeFunction): void {
+    convertChildNode = fn;
+  }
+  
+  /**
+   * Convert list node to DOCX elements (paragraphs, tables, etc.)
+   * @param node - List AST node
+   * @returns Array of DOCX FileChild elements
+   */
+  async function convertList(node: DOCXListNode): Promise<FileChild[]> {
+    const items: FileChild[] = [];
+    const listInstance = incrementListInstanceCounter();
+
+    for (const item of node.children) {
+      const converted = await convertListItem(node.ordered ?? false, item as ListItemNode, 0, listInstance);
+      if (converted) {
+        items.push(...converted);
+      }
+    }
+
+    return items;
+  }
+
+  /**
+   * Convert list item node to DOCX elements
+   * @param ordered - Whether the list is ordered
+   * @param node - ListItem AST node
+   * @param level - Current nesting level
+   * @param listInstance - List instance number for numbering
+   * @returns Array of DOCX FileChild elements
+   */
+  async function convertListItem(ordered: boolean, node: ListItemNode, level: number, listInstance: number): Promise<FileChild[]> {
+    const items: FileChild[] = [];
+    const isTaskList = node.checked !== null && node.checked !== undefined;
+
+    for (const child of node.children) {
+      if (child.type === 'paragraph') {
+        const paragraphChild = child as { type: string; children?: InlineNode[] };
+        const children = await convertInlineNodes(paragraphChild.children || []);
+
+        if (isTaskList) {
+          const checkboxSymbol = node.checked ? '▣' : '☐';
+          children.unshift(new TextRun({
+            text: checkboxSymbol + ' ',
+            font: defaultRun.font,
+            size: defaultRun.size,
+          }));
+        }
+
+        const defaultLineSpacing = defaultSpacing.line ?? 276;
+        const baseParagraphConfig: IParagraphOptions = {
+          children: children as ParagraphChild[],
+          spacing: { before: 0, after: 0, line: defaultLineSpacing },
+          alignment: AlignmentType.LEFT,
+        };
+
+        const paragraph = ordered && !isTaskList
+          ? new Paragraph({
+              ...baseParagraphConfig,
+              numbering: {
+                reference: 'default-ordered-list',
+                level: level,
+                instance: listInstance,
+              },
+            })
+          : new Paragraph({
+              ...baseParagraphConfig,
+              bullet: { level: level },
+            });
+
+        items.push(paragraph);
+      } else if (child.type === 'list') {
+        const listChild = child as DOCXListNode;
+        for (const nestedItem of listChild.children) {
+          items.push(...await convertListItem(listChild.ordered ?? false, nestedItem as ListItemNode, level + 1, listInstance));
+        }
+      } else if (convertChildNode) {
+        // Handle other node types (e.g., blockquote, code, table) within list items
+        // Pass the current list level for proper indentation
+        const converted = await convertChildNode(child as DOCXASTNode, level + 1);
+        if (converted) {
+          if (Array.isArray(converted)) {
+            items.push(...converted);
+          } else {
+            items.push(converted);
+          }
+        }
+      }
+    }
+
+    return items;
+  }
+
+  return { convertList, convertListItem, setConvertChildNode };
+}

--- a/markdown-sheet/src/lib/docx/docx-math-converter.ts
+++ b/markdown-sheet/src/lib/docx/docx-math-converter.ts
@@ -1,0 +1,167 @@
+/**
+ * DOCX Math Converter
+ * Converts LaTeX math expressions to DOCX-compatible OMML format
+ */
+
+import { convertToXmlComponent, XmlComponent } from 'docx';
+import { mathjax } from 'mathjax-full/js/mathjax';
+import { TeX } from 'mathjax-full/js/input/tex';
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages';
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html';
+import { SerializedMmlVisitor } from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor';
+import { STATE } from 'mathjax-full/js/core/MathItem';
+import { mml2omml } from './mml2omml';
+import { xml2js } from 'xml-js';
+import type { Element as XmlElement } from 'xml-js';
+
+/**
+ * MathJax environment interface
+ */
+interface MathJaxEnvironment {
+  adaptor: unknown;
+  document: {
+    convert: (input: string, options: { display: boolean; end: unknown }) => unknown;
+  };
+  visitor: SerializedMmlVisitor;
+}
+
+/**
+ * Parsed XML structure from xml-js
+ */
+interface ParsedXml {
+  elements?: XmlElement[];
+}
+
+let mathJaxEnvironment: MathJaxEnvironment | null = null;
+let mathJaxInitializing: Promise<void> | null = null;
+
+// Exclude bussproofs because it requires layout features that depend on typesetting output jax.
+const TEX_PACKAGES = AllPackages.filter((pkg: string) => pkg !== 'bussproofs');
+
+// LaTeX commands that MathJax doesn't support, mapped to Unicode characters
+// These are typically from packages like esint, stmaryrd, etc.
+const UNSUPPORTED_LATEX_COMMANDS: Record<string, string> = {
+  // Integral variants (esint package)
+  '\\oiint': '\u222F', // ∯ surface integral
+  '\\oiiint': '\u2230', // ∰ volume integral
+  '\\varointclockwise': '\u2232', // ∲ clockwise contour integral
+  '\\ointctrclockwise': '\u2233', // ∳ anticlockwise contour integral
+  '\\intclockwise': '\u2231', // ∱ clockwise integral
+
+  // Additional symbols that might not be supported
+  '\\amalg': '\u2A3F', // ⨿ amalgamation
+};
+
+/**
+ * Preprocess LaTeX string to replace unsupported commands with Unicode equivalents.
+ * This allows commands from packages like esint to work without MathJax support.
+ */
+function preprocessLatexCommands(latexString: string): string {
+  let result = latexString;
+  for (const [command, unicode] of Object.entries(UNSUPPORTED_LATEX_COMMANDS)) {
+    // Use regex to match the command (with word boundary to avoid partial matches)
+    const regex = new RegExp(command.replace(/\\/g, '\\\\') + '(?![a-zA-Z])', 'g');
+    result = result.replace(regex, unicode);
+  }
+  return result;
+}
+
+export function convertMathMl2Omml(mathMlString: string): string {
+  return mml2omml(mathMlString, { disableDecode: true });
+}
+
+function convertOmml2Math(ommlString: string): XmlComponent {
+  const parsed = xml2js(ommlString, {
+    compact: false,
+    ignoreDeclaration: true,
+    ignoreComment: true,
+    captureSpacesBetweenElements: true,
+  }) as ParsedXml;
+
+  const elements = parsed?.elements ?? [];
+  const mathElement = elements.find((element) => element.type === 'element' && element.name === 'm:oMath');
+
+  if (!mathElement) {
+    throw new Error('Invalid OMML content: missing m:oMath element');
+  }
+
+  const component = convertToXmlComponent(mathElement as unknown as Record<string, unknown>);
+
+  if (!component || typeof component === 'string') {
+    throw new Error('Failed to convert OMML element');
+  }
+
+  if ((component as unknown as { rootKey: string }).rootKey !== 'm:oMath') {
+    throw new Error('Failed to convert OMML element');
+  }
+
+  return component;
+}
+
+function convertMathMl2Math(mathMlString: string): XmlComponent {
+  const ommlString = convertMathMl2Omml(mathMlString);
+  return convertOmml2Math(ommlString);
+}
+
+function ensureMathJaxEnvironment(): MathJaxEnvironment {
+  if (mathJaxEnvironment) {
+    return mathJaxEnvironment;
+  }
+
+  const adaptor = liteAdaptor();
+  RegisterHTMLHandler(adaptor);
+
+  const tex = new TeX({ packages: TEX_PACKAGES });
+  const document = mathjax.document('', {
+    InputJax: tex,
+  });
+
+  const visitor = new SerializedMmlVisitor();
+
+  mathJaxEnvironment = { adaptor, document, visitor };
+  return mathJaxEnvironment!;
+}
+
+export async function mathJaxReady(): Promise<boolean> {
+  if (mathJaxEnvironment) {
+    return true;
+  }
+
+  if (mathJaxInitializing) {
+    await mathJaxInitializing;
+    return true;
+  }
+
+  mathJaxInitializing = Promise.resolve().then(() => {
+    ensureMathJaxEnvironment();
+  });
+
+  await mathJaxInitializing;
+  mathJaxInitializing = null;
+  return true;
+}
+
+function latex2MathMl(latexString: string): string {
+  if (typeof latexString !== 'string') {
+    throw new Error('latex2MathMl expects a string input');
+  }
+
+  // Preprocess unsupported LaTeX commands to Unicode equivalents
+  const preprocessed = preprocessLatexCommands(latexString);
+
+  const { document, visitor } = ensureMathJaxEnvironment();
+  const mathNode = document.convert(preprocessed, {
+    display: false,
+    end: STATE.CONVERT,
+  });
+
+  return visitor.visitTree(mathNode as any);
+}
+
+export function convertLatex2Math(latexString: string): XmlComponent {
+  const mathMlString = latex2MathMl(latexString);
+  return convertMathMl2Math(mathMlString);
+}
+
+export { convertMathMl2Math, convertOmml2Math };

--- a/markdown-sheet/src/lib/docx/docx-table-converter.ts
+++ b/markdown-sheet/src/lib/docx/docx-table-converter.ts
@@ -1,0 +1,270 @@
+// Table conversion for DOCX export
+
+import {
+  Paragraph,
+  TextRun,
+  AlignmentType,
+  Table,
+  TableCell,
+  TableRow,
+  BorderStyle,
+  TableLayoutType,
+  VerticalAlign as VerticalAlignTable,
+  VerticalMergeType,
+  WidthType,
+  convertInchesToTwip,
+  type IBorderOptions,
+  type IParagraphOptions,
+  type ITableCellOptions,
+  type ParagraphChild,
+} from 'docx';
+import type { DOCXThemeStyles, DOCXTableNode } from './types';
+import type { InlineResult, InlineNode } from './docx-inline-converter';
+import { 
+  calculateMergeInfoFromStringsWithAnalysis, 
+  extractTextFromAstCell,
+  type CellMergeInfo 
+} from './table-merge-utils';
+
+type ConvertInlineNodesFunction = (children: InlineNode[], options?: { bold?: boolean; size?: number; color?: string }) => Promise<InlineResult[]>;
+
+/** Table layout mode */
+export type TableLayout = 'left' | 'center';
+
+interface TableConverterOptions {
+  themeStyles: DOCXThemeStyles;
+  convertInlineNodes: ConvertInlineNodesFunction;
+  /** Enable auto-merge of empty table cells */
+  mergeEmptyCells?: boolean;
+  /** Table layout: 'left' or 'center' */
+  tableLayout?: TableLayout;
+}
+
+export interface TableConverter {
+  convertTable(node: DOCXTableNode, listLevel?: number): Promise<Table>;
+  /** Update merge setting at runtime */
+  setMergeEmptyCells(enabled: boolean): void;
+  /** Update table layout at runtime */
+  setTableLayout(layout: TableLayout): void;
+}
+
+/**
+ * Create a table converter
+ * @param options - Configuration options
+ * @returns Table converter
+ */
+export function createTableConverter({ themeStyles, convertInlineNodes, mergeEmptyCells = false, tableLayout = 'center' }: TableConverterOptions): TableConverter {
+  // Default table styles
+  const defaultMargins = { top: 80, bottom: 80, left: 100, right: 100 };
+  
+  // Get table styles with defaults
+  const tableStyles = themeStyles.tableStyles || {};
+  const headerStyles = tableStyles.header || {};
+  const cellStyles = tableStyles.cell || {};
+  const borderStyles = tableStyles.borders || {};
+  const zebraStyles = tableStyles.zebra;
+  
+  // Mutable settings
+  let enableMerge = mergeEmptyCells;
+  let currentLayout: TableLayout = tableLayout;
+  
+  /**
+   * Extract cell text content matrix from data rows (excluding header)
+   */
+  function extractCellMatrix(tableRows: DOCXTableNode['children']): string[][] {
+    // Skip header row (index 0)
+    const dataRows = tableRows.slice(1);
+    return dataRows.map(row => {
+      const cells = (row.children || []).filter(c => c.type === 'tableCell');
+      return cells.map(cell => extractTextFromAstCell(cell));
+    });
+  }
+  
+  /**
+   * Convert table node to DOCX Table
+   * @param node - Table AST node
+   * @param listLevel - List nesting level for indentation (default: 0)
+   * @returns DOCX Table
+   */
+  async function convertTable(node: DOCXTableNode, listLevel = 0): Promise<Table> {
+    const rows: TableRow[] = [];
+    const alignments = (node as unknown as { align?: Array<'left' | 'center' | 'right' | null> }).align || [];
+    const tableRows = (node.children || []).filter((row) => row.type === 'tableRow');
+    const rowCount = tableRows.length;
+
+    // Calculate merge info for data rows if merge is enabled
+    let mergeInfo: CellMergeInfo[][] | null = null;
+    let groupHeaderRows = new Set<number>();
+    if (enableMerge && rowCount > 1) {
+      const cellMatrix = extractCellMatrix(tableRows);
+      if (cellMatrix.length > 0 && cellMatrix[0].length > 0) {
+        const result = calculateMergeInfoFromStringsWithAnalysis(cellMatrix);
+        mergeInfo = result.mergeInfo;
+        // Get group header rows for potential styling
+        if (result.analysis) {
+          groupHeaderRows = new Set(result.analysis.groupHeaders.rows);
+        }
+      }
+    }
+
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const row = tableRows[rowIndex];
+      const isHeaderRow = rowIndex === 0;
+      const isLastRow = rowIndex === rowCount - 1;
+      const dataRowIndex = rowIndex - 1; // Index in data rows (excluding header)
+
+      if (row.type === 'tableRow') {
+        const cells: TableCell[] = [];
+
+        const rowChildren = row.children || [];
+        for (let colIndex = 0; colIndex < rowChildren.length; colIndex++) {
+          const cell = rowChildren[colIndex];
+
+          if (cell.type === 'tableCell') {
+            // Check if this cell should be skipped (merged into cell above)
+            if (!isHeaderRow && mergeInfo && dataRowIndex >= 0 && dataRowIndex < mergeInfo.length) {
+              const cellInfo = mergeInfo[dataRowIndex]?.[colIndex];
+              if (cellInfo && !cellInfo.shouldRender) {
+                // Skip this cell - it's merged into the cell above
+                continue;
+              }
+            }
+            
+            const isBold = isHeaderRow && (headerStyles.bold ?? true);
+            const headerColor = isHeaderRow && headerStyles.color ? headerStyles.color : undefined;
+            const children = isHeaderRow
+              ? await convertInlineNodes((cell.children || []) as InlineNode[], { bold: isBold, size: 20, color: headerColor })
+              : await convertInlineNodes((cell.children || []) as InlineNode[], { size: 20 });
+
+            const cellAlignment = alignments[colIndex];
+            let paragraphAlignment: (typeof AlignmentType)[keyof typeof AlignmentType] = AlignmentType.LEFT;
+            if (isHeaderRow) {
+              paragraphAlignment = AlignmentType.CENTER;
+            } else if (cellAlignment === 'center') {
+              paragraphAlignment = AlignmentType.CENTER;
+            } else if (cellAlignment === 'right') {
+              paragraphAlignment = AlignmentType.RIGHT;
+            }
+
+            const paragraphOptions: IParagraphOptions = {
+              children: children as ParagraphChild[],
+              alignment: paragraphAlignment,
+              spacing: { before: 60, after: 60, line: 240 },
+            };
+
+            const whiteBorder: IBorderOptions = { style: BorderStyle.SINGLE, size: 0, color: 'FFFFFF' };
+            const noneBorder: IBorderOptions = { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' };
+            const isFirstColumn = colIndex === 0;
+
+            let borders: ITableCellOptions['borders'];
+
+            if (borderStyles.all) {
+              borders = {
+                top: borderStyles.all,
+                bottom: borderStyles.all,
+                left: borderStyles.all,
+                right: borderStyles.all
+              };
+            } else {
+              borders = {
+                top: whiteBorder,
+                bottom: whiteBorder,
+                left: isFirstColumn ? whiteBorder : noneBorder,
+                right: noneBorder
+              };
+            }
+
+            if (isHeaderRow && borderStyles.headerTop && borderStyles.headerTop.style !== BorderStyle.NONE) {
+              borders = { ...(borders || {}), top: borderStyles.headerTop };
+            }
+            if (isHeaderRow && borderStyles.headerBottom && borderStyles.headerBottom.style !== BorderStyle.NONE) {
+              borders = { ...(borders || {}), bottom: borderStyles.headerBottom };
+            }
+            if (!isHeaderRow && borderStyles.insideHorizontal && borderStyles.insideHorizontal.style !== BorderStyle.NONE) {
+              // Apply inside horizontal border (will be overridden by lastRowBottom if needed)
+              borders = { ...(borders || {}), bottom: borderStyles.insideHorizontal };
+            }
+
+            let shading: ITableCellOptions['shading'];
+            if (isHeaderRow && headerStyles.shading) {
+              shading = headerStyles.shading;
+            } else if (rowIndex > 0 && typeof zebraStyles === 'object') {
+              const isOddDataRow = ((rowIndex - 1) % 2) === 0;
+              const background = isOddDataRow ? zebraStyles.odd : zebraStyles.even;
+              if (background !== 'ffffff' && background !== 'FFFFFF') {
+                shading = { fill: background };
+              }
+            }
+
+            // Calculate vertical merge for this cell
+            let rowSpan: number | undefined;
+            let cellSpansToLastRow = false;
+            if (!isHeaderRow && mergeInfo && dataRowIndex >= 0 && dataRowIndex < mergeInfo.length) {
+              const cellInfo = mergeInfo[dataRowIndex]?.[colIndex];
+              if (cellInfo && cellInfo.rowspan > 1) {
+                rowSpan = cellInfo.rowspan;
+                // Check if this cell spans to the last data row
+                // dataRowIndex is 0-based index in data rows, mergeInfo.length is total data rows
+                cellSpansToLastRow = (dataRowIndex + cellInfo.rowspan >= mergeInfo.length);
+              }
+            }
+            
+            // Calculate horizontal merge (colspan) for this cell
+            let colSpan: number | undefined;
+            if (!isHeaderRow && mergeInfo && dataRowIndex >= 0 && dataRowIndex < mergeInfo.length) {
+              const cellInfo = mergeInfo[dataRowIndex]?.[colIndex];
+              if (cellInfo && cellInfo.colspan > 1) {
+                colSpan = cellInfo.colspan;
+              }
+            }
+            
+            // Apply last row bottom border if this cell is in last row OR spans to last row
+            if (!isHeaderRow && (isLastRow || cellSpansToLastRow)) {
+              if (borderStyles.lastRowBottom && borderStyles.lastRowBottom.style !== BorderStyle.NONE) {
+                borders = { ...(borders || {}), bottom: borderStyles.lastRowBottom };
+              }
+            }
+
+            const cellConfig: ITableCellOptions = {
+              children: [new Paragraph(paragraphOptions)],
+              verticalAlign: VerticalAlignTable.CENTER,
+              margins: cellStyles.margins || defaultMargins,
+              borders,
+              shading,
+              rowSpan,      // Add vertical merge span
+              columnSpan: colSpan,  // Add horizontal merge span
+            };
+
+            cells.push(new TableCell(cellConfig));
+          }
+        }
+
+        rows.push(new TableRow({
+          children: cells,
+          tableHeader: isHeaderRow,
+        }));
+      }
+    }
+
+    // For nested tables, add half the indent to the left margin and keep center alignment
+    // This creates the visual effect of centering within the indented area
+    const indentSize = listLevel > 0 ? convertInchesToTwip(0.5 * listLevel / 2) : undefined;
+
+    return new Table({
+      rows: rows,
+      layout: TableLayoutType.AUTOFIT,
+      alignment: currentLayout === 'center' ? AlignmentType.CENTER : AlignmentType.LEFT,
+      indent: indentSize ? { size: indentSize, type: WidthType.DXA } : undefined,
+    });
+  }
+  
+  function setMergeEmptyCells(enabled: boolean): void {
+    enableMerge = enabled;
+  }
+
+  function setTableLayout(layout: TableLayout): void {
+    currentLayout = layout;
+  }
+
+  return { convertTable, setMergeEmptyCells, setTableLayout };
+}

--- a/markdown-sheet/src/lib/docx/mml2omml.ts
+++ b/markdown-sheet/src/lib/docx/mml2omml.ts
@@ -1,0 +1,2780 @@
+// @ts-nocheck
+// MML2OMML: MathML to Office Open XML Math converter
+// Adapted from mml2omml library - Skip TypeScript checking for this third-party code
+
+// Generated using scripts/write-decode-map.ts
+const xmlDecodeTree = /* #__PURE__ */ new Uint16Array(
+  // prettier-ignore
+  /* #__PURE__ */ '\u0200aglq\t\x15\x18\x1b\u026d\x0f\0\0\x12p;\u4026os;\u4027t;\u403et;\u403cuot;\u4022'
+    .split('')
+    .map((c) => c.charCodeAt(0))
+)
+
+// Unicode space characters for LaTeX spacing commands
+const UNICODE_SPACES = {
+  EM_SPACE: '\u2003', // 1em space (for \quad)
+  THIN_SPACE: '\u2009', // thin space (for \,)
+  MEDIUM_SPACE: '\u2005', // medium space (for \:)
+  THICK_SPACE: '\u2004', // thick space (for \;)
+  ZERO_WIDTH_SPACE: '\u200B' // zero-width space (for empty elements)
+}
+
+/**
+ * Decode HTML entities in a string to their Unicode equivalents.
+ * Handles both numeric (&#xHHHH; and &#DDD;) and named entities.
+ */
+function decodeHtmlEntities(str) {
+  if (!str) return str
+  return str
+    // Decode hex entities: &#xHHHH;
+    .replace(/&#x([0-9A-Fa-f]+);/g, (match, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    // Decode decimal entities: &#DDD;
+    .replace(/&#(\d+);/g, (match, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    // Common named entities
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+}
+
+// MathML named space values (approximate em values)
+const MATHML_NAMED_SPACES = {
+  veryverythinmathspace: 0.056, // 1/18 em
+  verythinmathspace: 0.111, // 2/18 em
+  thinmathspace: 0.167, // 3/18 em
+  mediummathspace: 0.222, // 4/18 em
+  thickmathspace: 0.278, // 5/18 em
+  verythickmathspace: 0.333, // 6/18 em
+  veryverythickmathspace: 0.389 // 7/18 em
+}
+
+/**
+ * Convert a space value (em, named, etc.) to Unicode space character.
+ */
+function spaceValueToUnicode(value) {
+  if (!value) return ''
+
+  let emValue = 0
+
+  // Check if it's a named space
+  if (MATHML_NAMED_SPACES[value] !== undefined) {
+    emValue = MATHML_NAMED_SPACES[value]
+  } else {
+    // Try to parse as numeric value
+    const numMatch = value.match(/^(-?[\d.]+)(em|pt|px)?$/)
+    if (numMatch) {
+      emValue = parseFloat(numMatch[1])
+      const unit = numMatch[2] || 'em'
+      // Convert pt/px to approximate em (assuming 1em ≈ 10pt)
+      if (unit === 'pt') emValue = emValue / 10
+      else if (unit === 'px') emValue = emValue / 16
+    }
+  }
+
+  // Map em value to Unicode space
+  if (emValue >= 1.8) {
+    return UNICODE_SPACES.EM_SPACE + UNICODE_SPACES.EM_SPACE // \qquad (2em)
+  } else if (emValue >= 0.8) {
+    return UNICODE_SPACES.EM_SPACE // \quad (1em)
+  } else if (emValue >= 0.25) {
+    return UNICODE_SPACES.THICK_SPACE // \; (5/18 em ≈ 0.278em)
+  } else if (emValue >= 0.19) {
+    return UNICODE_SPACES.MEDIUM_SPACE // \: (4/18 em ≈ 0.222em)
+  } else if (emValue > 0) {
+    return UNICODE_SPACES.THIN_SPACE // \, (3/18 em ≈ 0.167em)
+  }
+
+  return ''
+}
+
+// Adapted from https://github.com/mathiasbynens/he/blob/36afe179392226cf1b6ccdb16ebbb7a5a844d93a/src/he.js#L106-L134
+let _a
+const decodeMap = new Map([
+  [0, 65533],
+  // C1 Unicode control character reference replacements
+  [128, 8364],
+  [130, 8218],
+  [131, 402],
+  [132, 8222],
+  [133, 8230],
+  [134, 8224],
+  [135, 8225],
+  [136, 710],
+  [137, 8240],
+  [138, 352],
+  [139, 8249],
+  [140, 338],
+  [142, 381],
+  [145, 8216],
+  [146, 8217],
+  [147, 8220],
+  [148, 8221],
+  [149, 8226],
+  [150, 8211],
+  [151, 8212],
+  [152, 732],
+  [153, 8482],
+  [154, 353],
+  [155, 8250],
+  [156, 339],
+  [158, 382],
+  [159, 376]
+])
+/**
+ * Polyfill for `String.fromCodePoint`. It is used to create a string from a Unicode code point.
+ */
+const fromCodePoint =
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, n/no-unsupported-features/es-builtins
+  (_a = String.fromCodePoint) !== null && _a !== void 0
+    ? _a
+    : (codePoint) => {
+        let output = ''
+        if (codePoint > 65535) {
+          codePoint -= 65536
+          output += String.fromCharCode(((codePoint >>> 10) & 1023) | 55296)
+          codePoint = 56320 | (codePoint & 1023)
+        }
+        output += String.fromCharCode(codePoint)
+        return output
+      }
+/**
+ * Replace the given code point with a replacement character if it is a
+ * surrogate or is outside the valid range. Otherwise return the code
+ * point unchanged.
+ */
+function replaceCodePoint(codePoint) {
+  let _a
+  if ((codePoint >= 55296 && codePoint <= 57343) || codePoint > 1114111) {
+    return 65533
+  }
+  return (_a = decodeMap.get(codePoint)) !== null && _a !== void 0 ? _a : codePoint
+}
+
+let CharCodes
+;((CharCodes) => {
+  CharCodes[(CharCodes.NUM = 35)] = 'NUM'
+  CharCodes[(CharCodes.SEMI = 59)] = 'SEMI'
+  CharCodes[(CharCodes.EQUALS = 61)] = 'EQUALS'
+  CharCodes[(CharCodes.ZERO = 48)] = 'ZERO'
+  CharCodes[(CharCodes.NINE = 57)] = 'NINE'
+  CharCodes[(CharCodes.LOWER_A = 97)] = 'LOWER_A'
+  CharCodes[(CharCodes.LOWER_F = 102)] = 'LOWER_F'
+  CharCodes[(CharCodes.LOWER_X = 120)] = 'LOWER_X'
+  CharCodes[(CharCodes.LOWER_Z = 122)] = 'LOWER_Z'
+  CharCodes[(CharCodes.UPPER_A = 65)] = 'UPPER_A'
+  CharCodes[(CharCodes.UPPER_F = 70)] = 'UPPER_F'
+  CharCodes[(CharCodes.UPPER_Z = 90)] = 'UPPER_Z'
+})(CharCodes || (CharCodes = {}))
+/** Bit that needs to be set to convert an upper case ASCII character to lower case */
+const TO_LOWER_BIT = 32
+let BinTrieFlags
+;((BinTrieFlags) => {
+  BinTrieFlags[(BinTrieFlags.VALUE_LENGTH = 49152)] = 'VALUE_LENGTH'
+  BinTrieFlags[(BinTrieFlags.BRANCH_LENGTH = 16256)] = 'BRANCH_LENGTH'
+  BinTrieFlags[(BinTrieFlags.JUMP_TABLE = 127)] = 'JUMP_TABLE'
+})(BinTrieFlags || (BinTrieFlags = {}))
+function isNumber(code) {
+  return code >= CharCodes.ZERO && code <= CharCodes.NINE
+}
+function isHexadecimalCharacter(code) {
+  return (
+    (code >= CharCodes.UPPER_A && code <= CharCodes.UPPER_F) ||
+    (code >= CharCodes.LOWER_A && code <= CharCodes.LOWER_F)
+  )
+}
+function isAsciiAlphaNumeric(code) {
+  return (
+    (code >= CharCodes.UPPER_A && code <= CharCodes.UPPER_Z) ||
+    (code >= CharCodes.LOWER_A && code <= CharCodes.LOWER_Z) ||
+    isNumber(code)
+  )
+}
+/**
+ * Checks if the given character is a valid end character for an entity in an attribute.
+ *
+ * Attribute values that aren't terminated properly aren't parsed, and shouldn't lead to a parser error.
+ * See the example in https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
+ */
+function isEntityInAttributeInvalidEnd(code) {
+  return code === CharCodes.EQUALS || isAsciiAlphaNumeric(code)
+}
+let EntityDecoderState
+;((EntityDecoderState) => {
+  EntityDecoderState[(EntityDecoderState.EntityStart = 0)] = 'EntityStart'
+  EntityDecoderState[(EntityDecoderState.NumericStart = 1)] = 'NumericStart'
+  EntityDecoderState[(EntityDecoderState.NumericDecimal = 2)] = 'NumericDecimal'
+  EntityDecoderState[(EntityDecoderState.NumericHex = 3)] = 'NumericHex'
+  EntityDecoderState[(EntityDecoderState.NamedEntity = 4)] = 'NamedEntity'
+})(EntityDecoderState || (EntityDecoderState = {}))
+let DecodingMode
+;((DecodingMode) => {
+  /** Entities in text nodes that can end with any character. */
+  DecodingMode[(DecodingMode.Legacy = 0)] = 'Legacy'
+  /** Only allow entities terminated with a semicolon. */
+  DecodingMode[(DecodingMode.Strict = 1)] = 'Strict'
+  /** Entities in attributes have limitations on ending characters. */
+  DecodingMode[(DecodingMode.Attribute = 2)] = 'Attribute'
+})(DecodingMode || (DecodingMode = {}))
+/**
+ * Token decoder with support of writing partial entities.
+ */
+class EntityDecoder {
+  constructor(
+    /** The tree used to decode entities. */
+    decodeTree,
+    /**
+     * The function that is called when a codepoint is decoded.
+     *
+     * For multi-byte named entities, this will be called multiple times,
+     * with the second codepoint, and the same `consumed` value.
+     *
+     * @param codepoint The decoded codepoint.
+     * @param consumed The number of bytes consumed by the decoder.
+     */
+    emitCodePoint,
+    /** An object that is used to produce errors. */
+    errors
+  ) {
+    this.decodeTree = decodeTree
+    this.emitCodePoint = emitCodePoint
+    this.errors = errors
+    /** The current state of the decoder. */
+    this.state = EntityDecoderState.EntityStart
+    /** Characters that were consumed while parsing an entity. */
+    this.consumed = 1
+    /**
+     * The result of the entity.
+     *
+     * Either the result index of a numeric entity, or the codepoint of a
+     * numeric entity.
+     */
+    this.result = 0
+    /** The current index in the decode tree. */
+    this.treeIndex = 0
+    /** The number of characters that were consumed in excess. */
+    this.excess = 1
+    /** The mode in which the decoder is operating. */
+    this.decodeMode = DecodingMode.Strict
+  }
+  /** Resets the instance to make it reusable. */
+  startEntity(decodeMode) {
+    this.decodeMode = decodeMode
+    this.state = EntityDecoderState.EntityStart
+    this.result = 0
+    this.treeIndex = 0
+    this.excess = 1
+    this.consumed = 1
+  }
+  /**
+   * Write an entity to the decoder. This can be called multiple times with partial entities.
+   * If the entity is incomplete, the decoder will return -1.
+   *
+   * Mirrors the implementation of `getDecoder`, but with the ability to stop decoding if the
+   * entity is incomplete, and resume when the next string is written.
+   *
+   * @param input The string containing the entity (or a continuation of the entity).
+   * @param offset The offset at which the entity begins. Should be 0 if this is not the first call.
+   * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+   */
+  write(input, offset) {
+    switch (this.state) {
+      case EntityDecoderState.EntityStart: {
+        if (input.charCodeAt(offset) === CharCodes.NUM) {
+          this.state = EntityDecoderState.NumericStart
+          this.consumed += 1
+          return this.stateNumericStart(input, offset + 1)
+        }
+        this.state = EntityDecoderState.NamedEntity
+        return this.stateNamedEntity(input, offset)
+      }
+      case EntityDecoderState.NumericStart: {
+        return this.stateNumericStart(input, offset)
+      }
+      case EntityDecoderState.NumericDecimal: {
+        return this.stateNumericDecimal(input, offset)
+      }
+      case EntityDecoderState.NumericHex: {
+        return this.stateNumericHex(input, offset)
+      }
+      case EntityDecoderState.NamedEntity: {
+        return this.stateNamedEntity(input, offset)
+      }
+    }
+  }
+  /**
+   * Switches between the numeric decimal and hexadecimal states.
+   *
+   * Equivalent to the `Numeric character reference state` in the HTML spec.
+   *
+   * @param input The string containing the entity (or a continuation of the entity).
+   * @param offset The current offset.
+   * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+   */
+  stateNumericStart(input, offset) {
+    if (offset >= input.length) {
+      return -1
+    }
+    if ((input.charCodeAt(offset) | TO_LOWER_BIT) === CharCodes.LOWER_X) {
+      this.state = EntityDecoderState.NumericHex
+      this.consumed += 1
+      return this.stateNumericHex(input, offset + 1)
+    }
+    this.state = EntityDecoderState.NumericDecimal
+    return this.stateNumericDecimal(input, offset)
+  }
+  addToNumericResult(input, start, end, base) {
+    if (start !== end) {
+      const digitCount = end - start
+      this.result =
+        this.result * base ** digitCount + Number.parseInt(input.substr(start, digitCount), base)
+      this.consumed += digitCount
+    }
+  }
+  /**
+   * Parses a hexadecimal numeric entity.
+   *
+   * Equivalent to the `Hexademical character reference state` in the HTML spec.
+   *
+   * @param input The string containing the entity (or a continuation of the entity).
+   * @param offset The current offset.
+   * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+   */
+  stateNumericHex(input, offset) {
+    const startIndex = offset
+    while (offset < input.length) {
+      const char = input.charCodeAt(offset)
+      if (isNumber(char) || isHexadecimalCharacter(char)) {
+        offset += 1
+      } else {
+        this.addToNumericResult(input, startIndex, offset, 16)
+        return this.emitNumericEntity(char, 3)
+      }
+    }
+    this.addToNumericResult(input, startIndex, offset, 16)
+    return -1
+  }
+  /**
+   * Parses a decimal numeric entity.
+   *
+   * Equivalent to the `Decimal character reference state` in the HTML spec.
+   *
+   * @param input The string containing the entity (or a continuation of the entity).
+   * @param offset The current offset.
+   * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+   */
+  stateNumericDecimal(input, offset) {
+    const startIndex = offset
+    while (offset < input.length) {
+      const char = input.charCodeAt(offset)
+      if (isNumber(char)) {
+        offset += 1
+      } else {
+        this.addToNumericResult(input, startIndex, offset, 10)
+        return this.emitNumericEntity(char, 2)
+      }
+    }
+    this.addToNumericResult(input, startIndex, offset, 10)
+    return -1
+  }
+  /**
+   * Validate and emit a numeric entity.
+   *
+   * Implements the logic from the `Hexademical character reference start
+   * state` and `Numeric character reference end state` in the HTML spec.
+   *
+   * @param lastCp The last code point of the entity. Used to see if the
+   *               entity was terminated with a semicolon.
+   * @param expectedLength The minimum number of characters that should be
+   *                       consumed. Used to validate that at least one digit
+   *                       was consumed.
+   * @returns The number of characters that were consumed.
+   */
+  emitNumericEntity(lastCp, expectedLength) {
+    let _a
+    // Ensure we consumed at least one digit.
+    if (this.consumed <= expectedLength) {
+      ;(_a = this.errors) === null || _a === void 0
+        ? void 0
+        : _a.absenceOfDigitsInNumericCharacterReference(this.consumed)
+      return 0
+    }
+    // Figure out if this is a legit end of the entity
+    if (lastCp === CharCodes.SEMI) {
+      this.consumed += 1
+    } else if (this.decodeMode === DecodingMode.Strict) {
+      return 0
+    }
+    this.emitCodePoint(replaceCodePoint(this.result), this.consumed)
+    if (this.errors) {
+      if (lastCp !== CharCodes.SEMI) {
+        this.errors.missingSemicolonAfterCharacterReference()
+      }
+      this.errors.validateNumericCharacterReference(this.result)
+    }
+    return this.consumed
+  }
+  /**
+   * Parses a named entity.
+   *
+   * Equivalent to the `Named character reference state` in the HTML spec.
+   *
+   * @param input The string containing the entity (or a continuation of the entity).
+   * @param offset The current offset.
+   * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+   */
+  stateNamedEntity(input, offset) {
+    const { decodeTree } = this
+    let current = decodeTree[this.treeIndex]
+    // The mask is the number of bytes of the value, including the current byte.
+    let valueLength = (current & BinTrieFlags.VALUE_LENGTH) >> 14
+    for (; offset < input.length; offset++, this.excess++) {
+      const char = input.charCodeAt(offset)
+      this.treeIndex = determineBranch(
+        decodeTree,
+        current,
+        this.treeIndex + Math.max(1, valueLength),
+        char
+      )
+      if (this.treeIndex < 0) {
+        return this.result === 0 ||
+          // If we are parsing an attribute
+          (this.decodeMode === DecodingMode.Attribute &&
+            // We shouldn't have consumed any characters after the entity,
+            (valueLength === 0 ||
+              // And there should be no invalid characters.
+              isEntityInAttributeInvalidEnd(char)))
+          ? 0
+          : this.emitNotTerminatedNamedEntity()
+      }
+      current = decodeTree[this.treeIndex]
+      valueLength = (current & BinTrieFlags.VALUE_LENGTH) >> 14
+      // If the branch is a value, store it and continue
+      if (valueLength !== 0) {
+        // If the entity is terminated by a semicolon, we are done.
+        if (char === CharCodes.SEMI) {
+          return this.emitNamedEntityData(this.treeIndex, valueLength, this.consumed + this.excess)
+        }
+        // If we encounter a non-terminated (legacy) entity while parsing strictly, then ignore it.
+        if (this.decodeMode !== DecodingMode.Strict) {
+          this.result = this.treeIndex
+          this.consumed += this.excess
+          this.excess = 0
+        }
+      }
+    }
+    return -1
+  }
+  /**
+   * Emit a named entity that was not terminated with a semicolon.
+   *
+   * @returns The number of characters consumed.
+   */
+  emitNotTerminatedNamedEntity() {
+    let _a
+    const { result, decodeTree } = this
+    const valueLength = (decodeTree[result] & BinTrieFlags.VALUE_LENGTH) >> 14
+    this.emitNamedEntityData(result, valueLength, this.consumed)
+    ;(_a = this.errors) === null || _a === void 0
+      ? void 0
+      : _a.missingSemicolonAfterCharacterReference()
+    return this.consumed
+  }
+  /**
+   * Emit a named entity.
+   *
+   * @param result The index of the entity in the decode tree.
+   * @param valueLength The number of bytes in the entity.
+   * @param consumed The number of characters consumed.
+   *
+   * @returns The number of characters consumed.
+   */
+  emitNamedEntityData(result, valueLength, consumed) {
+    const { decodeTree } = this
+    this.emitCodePoint(
+      valueLength === 1 ? decodeTree[result] & ~BinTrieFlags.VALUE_LENGTH : decodeTree[result + 1],
+      consumed
+    )
+    if (valueLength === 3) {
+      // For multi-byte values, we need to emit the second byte.
+      this.emitCodePoint(decodeTree[result + 2], consumed)
+    }
+    return consumed
+  }
+  /**
+   * Signal to the parser that the end of the input was reached.
+   *
+   * Remaining data will be emitted and relevant errors will be produced.
+   *
+   * @returns The number of characters consumed.
+   */
+  end() {
+    let _a
+    switch (this.state) {
+      case EntityDecoderState.NamedEntity: {
+        // Emit a named entity if we have one.
+        return this.result !== 0 &&
+          (this.decodeMode !== DecodingMode.Attribute || this.result === this.treeIndex)
+          ? this.emitNotTerminatedNamedEntity()
+          : 0
+      }
+      // Otherwise, emit a numeric entity if we have one.
+      case EntityDecoderState.NumericDecimal: {
+        return this.emitNumericEntity(0, 2)
+      }
+      case EntityDecoderState.NumericHex: {
+        return this.emitNumericEntity(0, 3)
+      }
+      case EntityDecoderState.NumericStart: {
+        ;(_a = this.errors) === null || _a === void 0
+          ? void 0
+          : _a.absenceOfDigitsInNumericCharacterReference(this.consumed)
+        return 0
+      }
+      case EntityDecoderState.EntityStart: {
+        // Return 0 if we have no entity.
+        return 0
+      }
+    }
+  }
+}
+/**
+ * Creates a function that decodes entities in a string.
+ *
+ * @param decodeTree The decode tree.
+ * @returns A function that decodes entities in a string.
+ */
+function getDecoder(decodeTree) {
+  let returnValue = ''
+  const decoder = new EntityDecoder(decodeTree, (data) => (returnValue += fromCodePoint(data)))
+  return function decodeWithTrie(input, decodeMode) {
+    let lastIndex = 0
+    let offset = 0
+    while ((offset = input.indexOf('&', offset)) >= 0) {
+      returnValue += input.slice(lastIndex, offset)
+      decoder.startEntity(decodeMode)
+      const length = decoder.write(
+        input,
+        // Skip the "&"
+        offset + 1
+      )
+      if (length < 0) {
+        lastIndex = offset + decoder.end()
+        break
+      }
+      lastIndex = offset + length
+      // If `length` is 0, skip the current `&` and continue.
+      offset = length === 0 ? lastIndex + 1 : lastIndex
+    }
+    const result = returnValue + input.slice(lastIndex)
+    // Make sure we don't keep a reference to the final string.
+    returnValue = ''
+    return result
+  }
+}
+/**
+ * Determines the branch of the current node that is taken given the current
+ * character. This function is used to traverse the trie.
+ *
+ * @param decodeTree The trie.
+ * @param current The current node.
+ * @param nodeIdx The index right after the current node and its value.
+ * @param char The current character.
+ * @returns The index of the next node, or -1 if no branch is taken.
+ */
+function determineBranch(decodeTree, current, nodeIndex, char) {
+  const branchCount = (current & BinTrieFlags.BRANCH_LENGTH) >> 7
+  const jumpOffset = current & BinTrieFlags.JUMP_TABLE
+  // Case 1: Single branch encoded in jump offset
+  if (branchCount === 0) {
+    return jumpOffset !== 0 && char === jumpOffset ? nodeIndex : -1
+  }
+  // Case 2: Multiple branches encoded in jump table
+  if (jumpOffset) {
+    const value = char - jumpOffset
+    return value < 0 || value >= branchCount ? -1 : decodeTree[nodeIndex + value] - 1
+  }
+  // Case 3: Multiple branches encoded in dictionary
+  // Binary search for the character.
+  let lo = nodeIndex
+  let hi = lo + branchCount - 1
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    const midValue = decodeTree[mid]
+    if (midValue < char) {
+      lo = mid + 1
+    } else if (midValue > char) {
+      hi = mid - 1
+    } else {
+      return decodeTree[mid + branchCount]
+    }
+  }
+  return -1
+}
+const xmlDecoder = /* #__PURE__ */ getDecoder(xmlDecodeTree)
+/**
+ * Decodes an XML string, requiring all entities to be terminated by a semicolon.
+ *
+ * @param xmlString The string to decode.
+ * @returns The decoded string.
+ */
+function decodeXML(xmlString) {
+  return xmlDecoder(xmlString, DecodingMode.Strict)
+}
+
+const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?(".*?"|'.*?')/g
+
+function stringify$1(tag) {
+  const res = {
+    type: 'tag',
+    name: '',
+    voidElement: false,
+    attribs: {},
+    children: []
+  }
+
+  const tagMatch = tag.match(/<\/?([^\s]+?)[/\s>]/)
+  if (tagMatch) {
+    res.name = tagMatch[1]
+    if (tag.charAt(tag.length - 2) === '/') {
+      res.voidElement = true
+    }
+
+    // handle comment tag
+    if (res.name.startsWith('!--')) {
+      const endIndex = tag.indexOf('-->')
+      return {
+        type: 'comment',
+        comment: endIndex !== -1 ? tag.slice(4, endIndex) : ''
+      }
+    }
+  }
+
+  const reg = new RegExp(attrRE)
+  let result = null
+  for (;;) {
+    result = reg.exec(tag)
+
+    if (result === null) {
+      break
+    }
+
+    if (!result[0].trim()) {
+      continue
+    }
+
+    if (result[1]) {
+      const attr = result[1].trim()
+      let arr = [attr, '']
+
+      if (attr.indexOf('=') > -1) {
+        arr = attr.split('=')
+      }
+
+      res.attribs[arr[0]] = arr[1]
+      reg.lastIndex--
+    } else if (result[2]) {
+      res.attribs[result[2]] = result[3].trim().substring(1, result[3].length - 1)
+    }
+  }
+
+  return res
+}
+
+const tagRE = /<[a-zA-Z0-9\-!/](?:"[^"]*"|'[^']*'|[^'">])*>/g
+const whitespaceRE = /^\s*$/
+
+const textContainerNames = ['mtext', 'mi', 'mn', 'mo', 'ms']
+
+// re-used obj for quick lookups of components
+const empty = Object.create(null)
+
+function parse(html, options) {
+  options || (options = {})
+  options.components || (options.components = empty)
+  const result = []
+  const arr = []
+  let current
+  let level = -1
+
+  html.replace(tagRE, (tag, index) => {
+    const isOpen = tag.charAt(1) !== '/'
+    const isComment = tag.startsWith('<!--')
+    const start = index + tag.length
+    const nextChar = html.charAt(start)
+    let parent
+
+    if (isComment) {
+      const comment = stringify$1(tag)
+
+      // if we're at root, push new base node
+      if (level < 0) {
+        result.push(comment)
+        return result
+      }
+      parent = arr[level]
+      parent.children.push(comment)
+      return result
+    }
+
+    if (isOpen) {
+      level++
+
+      current = stringify$1(tag)
+      if (current.type === 'tag' && options.components[current.name]) {
+        current.type = 'component'
+      }
+
+      if (
+        textContainerNames.includes(current.name) &&
+        !current.voidElement &&
+        nextChar &&
+        nextChar !== '<'
+      ) {
+        const data = html.slice(start, html.indexOf('<', start)).trim()
+        current.children.push({
+          type: 'text',
+          data: options.disableDecode ? data : decodeXML(data)
+        })
+      }
+
+      // if we're at root, push new base node
+      if (level === 0) {
+        result.push(current)
+      }
+
+      parent = arr[level - 1]
+
+      if (parent) {
+        parent.children.push(current)
+      }
+
+      arr[level] = current
+    }
+
+    if (!isOpen || current.voidElement) {
+      if (level > -1 && (current.voidElement || current.name === tag.slice(2, -1))) {
+        level--
+        // move current up a level to match the end tag
+        current = level === -1 ? result : arr[level]
+      }
+      if (
+        level > -1 &&
+        textContainerNames.includes[arr[level].name] &&
+        nextChar !== '<' &&
+        nextChar
+      ) {
+        // trailing text node
+        parent = arr[level].children
+
+        // calculate correct end of the content slice in case there's
+        // no tag after the text node.
+        const end = html.indexOf('<', start)
+        let data = html.slice(start, end === -1 ? undefined : end)
+        // if a node is nothing but whitespace, collapse it as the spec states:
+        // https://www.w3.org/TR/html4/struct/text.html#h-9.1
+        if (whitespaceRE.test(data)) {
+          data = ' '
+        }
+        // don't add whitespace-only text nodes if they would be trailing text nodes
+        // or if they would be leading whitespace-only text nodes:
+        //  * end > -1 indicates this is not a trailing text node
+        //  * leading node is when level is -1 and parent has length 0
+        if ((end > -1 && level + parent.length >= 0) || data !== ' ') {
+          parent.push({
+            type: 'text',
+            data: options.disableDecode ? data : decodeXML(data)
+          })
+        }
+      }
+    }
+  })
+
+  return result
+}
+
+function attrString(attribs) {
+  const buff = []
+  for (const key in attribs) {
+    buff.push(`${key}="${attribs[key]}"`)
+  }
+  if (!buff.length) {
+    return ''
+  }
+  return ` ${buff.join(' ')}`
+}
+
+function stringify(buff, doc) {
+  switch (doc.type) {
+    case 'text':
+      return buff + doc.data
+    case 'tag': {
+      const voidElement =
+        doc.voidElement || (!doc.children.length && doc.attribs['xml:space'] !== 'preserve')
+      buff += `<${doc.name}${doc.attribs ? attrString(doc.attribs) : ''}${voidElement ? '/>' : '>'}`
+      if (voidElement) {
+        return buff
+      }
+      return `${buff + doc.children.reduce(stringify, '')}</${doc.name}>`
+    }
+    case 'comment':
+      buff += `<!--${doc.comment}-->`
+      return buff
+  }
+}
+
+function stringifyDoc(doc) {
+  return doc.reduce((token, rootEl) => token + stringify('', rootEl), '')
+}
+
+function getTextContent(node, trim = true) {
+  let returnString = ''
+  if (node.type === 'text') {
+    let text = node.data.replace(/[\u2062]|[\u200B]/g, '')
+    if (trim) {
+      text = text.trim()
+    }
+    returnString += text
+  } else if (node.children) {
+    node.children.forEach((subNode) => {
+      returnString += getTextContent(subNode, trim)
+    })
+  }
+  return returnString
+}
+
+const NARY_REGEXP = /^[\u220f-\u2211]|[\u2229-\u2233]|[\u22c0-\u22c3]$/
+const GROW_REGEXP = /^\u220f|\u2211|[\u2229-\u222b]|\u222e|\u222f|\u2232|\u2233|[\u22c0-\u22c3]$/
+
+function getNary(node) {
+  // Check if node contains only a nary operator.
+  const text = getTextContent(node)
+  if (NARY_REGEXP.test(text)) {
+    return text
+  }
+  return false
+}
+
+function getNaryTarget(naryChar, element, type, subHide = false, supHide = false) {
+  const stretchy = element.attribs?.stretchy
+  const grow =
+    stretchy === 'true' ? '1' : stretchy === 'false' ? '0' : GROW_REGEXP.test(naryChar) ? '1' : '0'
+  return {
+    type: 'tag',
+    name: 'm:nary',
+    attribs: {},
+    children: [
+      {
+        type: 'tag',
+        name: 'm:naryPr',
+        attribs: {},
+        children: [
+          { type: 'tag', name: 'm:chr', attribs: { 'm:val': naryChar }, children: [] },
+          { type: 'tag', name: 'm:limLoc', attribs: { 'm:val': type }, children: [] },
+          { type: 'tag', name: 'm:grow', attribs: { 'm:val': grow }, children: [] },
+          {
+            type: 'tag',
+            name: 'm:subHide',
+            attribs: { 'm:val': subHide ? 'on' : 'off' },
+            children: []
+          },
+          {
+            type: 'tag',
+            name: 'm:supHide',
+            attribs: { 'm:val': supHide ? 'on' : 'off' },
+            children: []
+          }
+        ]
+      }
+    ]
+  }
+}
+
+function addScriptlevel(target, ancestors) {
+  const scriptlevel = ancestors.find((ancestor) => ancestor.attribs?.scriptlevel)?.attribs
+    ?.scriptlevel
+  if (['0', '1', '2'].includes(scriptlevel)) {
+    target.children.unshift({
+      type: 'tag',
+      name: 'm:argPr',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:scrLvl',
+          attribs: { 'm:val': scriptlevel },
+          children: []
+        }
+      ]
+    })
+  }
+}
+
+function math(element, targetParent, previousSibling, nextSibling, ancestors) {
+  targetParent.name = 'm:oMath'
+  targetParent.attribs = {
+    'xmlns:m': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
+    'xmlns:w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+  }
+  targetParent.type = 'tag'
+  targetParent.children = []
+  return targetParent
+}
+
+function semantics(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Ignore as default behavior
+  return targetParent
+}
+
+function menclose(element, targetParent, previousSibling, nextSibling, ancestors) {
+  const type = element.attribs?.notation?.split(' ')[0] || 'longdiv'
+
+  const targetElement = {
+    type: 'tag',
+    name: 'm:e',
+    attribs: {},
+    children: []
+  }
+
+  if (type === 'longdiv') {
+    targetParent.children.push({
+      type: 'tag',
+      name: 'm:rad',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:radPr',
+          attribs: {},
+          children: [{ type: 'tag', name: 'm:degHide', attribs: { 'm:val': 'on' }, children: [] }]
+        },
+        { type: 'tag', name: 'm:deg', attribs: {}, children: [] },
+        targetElement
+      ]
+    })
+  } else {
+    const hide = {
+      t: { type: 'tag', name: 'm:hideTop', attribs: { 'm:val': 'on' }, children: [] },
+      b: { type: 'tag', name: 'm:hideBot', attribs: { 'm:val': 'on' }, children: [] },
+      l: { type: 'tag', name: 'm:hideLeft', attribs: { 'm:val': 'on' }, children: [] },
+      r: { type: 'tag', name: 'm:hideRight', attribs: { 'm:val': 'on' }, children: [] }
+    }
+    const borderBoxPr = { type: 'tag', name: 'm:borderBoxPr', attribs: {}, children: [] }
+
+    const containerElement = {
+      type: 'tag',
+      name: 'm:borderBox',
+      attribs: {},
+      children: []
+    }
+    switch (type) {
+      case 'actuarial':
+      case 'radical':
+      case 'box':
+        containerElement.children = [targetElement]
+        break
+      case 'left':
+      case 'roundedbox':
+        borderBoxPr.children = [hide.t, hide.b, hide.r]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'right':
+      case 'circle':
+        borderBoxPr.children = [hide.t, hide.b, hide.l]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'top':
+        borderBoxPr.children = [hide.b, hide.l, hide.r]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'bottom':
+        borderBoxPr.children = [hide.t, hide.l, hide.r]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'updiagonalstrike':
+        borderBoxPr.children = [
+          hide.t,
+          hide.b,
+          hide.l,
+          hide.r,
+          { type: 'tag', name: 'm:strikeBLTR', attribs: { 'm:val': 'on' }, children: [] }
+        ]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'downdiagonalstrike':
+        borderBoxPr.children = [
+          hide.t,
+          hide.b,
+          hide.l,
+          hide.r,
+          { type: 'tag', name: 'm:strikeTLBR', attribs: { 'm:val': 'on' }, children: [] }
+        ]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'verticalstrike':
+        borderBoxPr.children = [
+          hide.t,
+          hide.b,
+          hide.l,
+          hide.r,
+          { type: 'tag', name: 'm:strikeV', attribs: { 'm:val': 'on' }, children: [] }
+        ]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      case 'horizontalstrike':
+        borderBoxPr.children = [
+          hide.t,
+          hide.b,
+          hide.l,
+          hide.r,
+          { type: 'tag', name: 'm:strikeH', attribs: { 'm:val': 'on' }, children: [] }
+        ]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+      default:
+        borderBoxPr.children = [hide.t, hide.b, hide.l, hide.r]
+        containerElement.children = [borderBoxPr, targetElement]
+        break
+    }
+    targetParent.children.push(containerElement)
+  }
+  return targetElement
+}
+
+function mfrac(element, targetParent, previousSibling, nextSibling, ancestors) {
+  if (element.children.length !== 2) {
+    // treat as mrow
+    return targetParent
+  }
+
+  const numerator = element.children[0]
+  const denumerator = element.children[1]
+  const numeratorTarget = {
+    name: 'm:num',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  const denumeratorTarget = {
+    name: 'm:den',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+  walker(numerator, numeratorTarget, false, false, ancestors)
+  walker(denumerator, denumeratorTarget, false, false, ancestors)
+  const fracType = element.attribs?.linethickness === '0' ? 'noBar' : 'bar'
+  targetParent.children.push({
+    type: 'tag',
+    name: 'm:f',
+    attribs: {},
+    children: [
+      {
+        type: 'tag',
+        name: 'm:fPr',
+        attribs: {},
+        children: [
+          {
+            type: 'tag',
+            name: 'm:type',
+            attribs: {
+              'm:val': fracType
+            },
+            children: []
+          }
+        ]
+      },
+      numeratorTarget,
+      denumeratorTarget
+    ]
+  })
+  // Don't iterate over children in the usual way.
+}
+
+function mglyph(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // No support in omml. Output alt text.
+  if (element.attribs?.alt) {
+    targetParent.children.push({
+      type: 'text',
+      data: element.attribs.alt
+    })
+  }
+}
+
+function mmultiscripts(element, targetParent, previousSibling, nextSibling, ancestors) {
+  if (element.children.length === 0) {
+    // Don't use
+    return
+  }
+
+  const base = element.children[0]
+  const postSubs = []
+  const postSupers = []
+  const preSubs = []
+  const preSupers = []
+  const children = element.children.slice(1)
+  let dividerFound = false
+  children.forEach((child, index) => {
+    if (child.name === 'mprescripts') {
+      dividerFound = true
+    } else if (child.name !== 'none') {
+      if (index % 2) {
+        if (dividerFound) {
+          preSubs.push(child)
+        } else {
+          postSupers.push(child)
+        }
+      } else {
+        if (dividerFound) {
+          preSupers.push(child)
+        } else {
+          postSubs.push(child)
+        }
+      }
+    }
+  })
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+  const tempTarget = {
+    children: []
+  }
+  walker(base, tempTarget, false, false, ancestors)
+  let topTarget = tempTarget.children[0]
+
+  if (postSubs.length || postSupers.length) {
+    const subscriptTarget = {
+      name: 'm:sub',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    postSubs.forEach((subscript) => walker(subscript, subscriptTarget, false, false, ancestors))
+
+    const superscriptTarget = {
+      name: 'm:sup',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+
+    postSupers.forEach((superscript) =>
+      walker(superscript, superscriptTarget, false, false, ancestors)
+    )
+
+    const topPostTarget = {
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:e',
+          attribs: {},
+          children: [topTarget]
+        }
+      ]
+    }
+    if (postSubs.length && postSupers.length) {
+      topPostTarget.name = 'm:sSubSup'
+      topPostTarget.children.push(subscriptTarget)
+      topPostTarget.children.push(superscriptTarget)
+    } else if (postSubs.length) {
+      topPostTarget.name = 'm:sSub'
+      topPostTarget.children.push(subscriptTarget)
+    } else {
+      topPostTarget.name = 'm:sSup'
+      topPostTarget.children.push(superscriptTarget)
+    }
+    topTarget = topPostTarget
+  }
+
+  if (preSubs.length || preSupers.length) {
+    const preSubscriptTarget = {
+      name: 'm:sub',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    preSubs.forEach((subscript) => walker(subscript, preSubscriptTarget, false, false, ancestors))
+
+    const preSuperscriptTarget = {
+      name: 'm:sup',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+
+    preSupers.forEach((superscript) =>
+      walker(superscript, preSuperscriptTarget, false, false, ancestors)
+    )
+    const topPreTarget = {
+      name: 'm:sPre',
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          name: 'm:e',
+          type: 'tag',
+          attribs: {},
+          children: [topTarget]
+        },
+        preSubscriptTarget,
+        preSuperscriptTarget
+      ]
+    }
+    topTarget = topPreTarget
+  }
+  targetParent.children.push(topTarget)
+  // Don't iterate over children in the usual way.
+}
+
+function mrow(element, targetParent, previousSibling, nextSibling, ancestors) {
+  if (previousSibling.isNary) {
+    const targetSibling = targetParent.children[targetParent.children.length - 1]
+    return targetSibling.children[targetSibling.children.length - 1]
+  }
+
+  // Check if this is a delimiter group (INNER class with OPEN/CLOSE mo elements)
+  // MathJax generates: <mrow data-mjx-texclass="INNER"><mo data-mjx-texclass="OPEN">...</mo>...<mo data-mjx-texclass="CLOSE">...</mo></mrow>
+  const texclass = element.attribs?.['data-mjx-texclass']
+  if (texclass === 'INNER' && element.children?.length >= 2) {
+    const firstChild = element.children[0]
+    const lastChild = element.children[element.children.length - 1]
+
+    // Check if first child is OPEN delimiter and last child is CLOSE delimiter
+    const isOpenDelimiter =
+      firstChild.name === 'mo' && firstChild.attribs?.['data-mjx-texclass'] === 'OPEN'
+    const isCloseDelimiter =
+      lastChild.name === 'mo' && lastChild.attribs?.['data-mjx-texclass'] === 'CLOSE'
+
+    if (isOpenDelimiter && isCloseDelimiter) {
+      // Extract delimiter characters and decode HTML entities
+      const openChar = decodeHtmlEntities(getTextContent(firstChild))
+      const closeChar = decodeHtmlEntities(getTextContent(lastChild))
+
+      // Create m:d delimiter structure
+      const contentTarget = {
+        name: 'm:e',
+        type: 'tag',
+        attribs: {},
+        children: []
+      }
+
+      const delimElement = {
+        name: 'm:d',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:dPr',
+            type: 'tag',
+            attribs: {},
+            children: [
+              {
+                name: 'm:begChr',
+                type: 'tag',
+                attribs: { 'm:val': openChar },
+                children: []
+              },
+              {
+                name: 'm:endChr',
+                type: 'tag',
+                attribs: { 'm:val': closeChar },
+                children: []
+              }
+            ]
+          },
+          contentTarget
+        ]
+      }
+
+      targetParent.children.push(delimElement)
+
+      // Process inner children (skip first and last which are the delimiters)
+      const innerChildren = element.children.slice(1, -1)
+      if (innerChildren.length > 0) {
+        ancestors = [...ancestors]
+        ancestors.unshift(element)
+        for (let i = 0; i < innerChildren.length; i++) {
+          walker(
+            innerChildren[i],
+            contentTarget,
+            innerChildren[i - 1],
+            innerChildren[i + 1],
+            ancestors
+          )
+        }
+      }
+
+      // Return null to prevent default child processing
+      return null
+    }
+  }
+
+  // Check if this is a binomial coefficient pattern (ORD class with nested OPEN/CLOSE mrow elements)
+  // MathJax generates for \binom{n}{k}:
+  // <mrow data-mjx-texclass="ORD">
+  //   <mrow data-mjx-texclass="OPEN"><mo minsize="1.2em" maxsize="1.2em">(</mo></mrow>
+  //   <mfrac linethickness="0">...</mfrac>
+  //   <mrow data-mjx-texclass="CLOSE"><mo minsize="1.2em" maxsize="1.2em">)</mo></mrow>
+  // </mrow>
+  if (texclass === 'ORD' && element.children?.length >= 3) {
+    const firstChild = element.children[0]
+    const lastChild = element.children[element.children.length - 1]
+
+    // Check if first child is mrow with OPEN class containing mo
+    const isOpenWrapper =
+      firstChild.name === 'mrow' &&
+      firstChild.attribs?.['data-mjx-texclass'] === 'OPEN' &&
+      firstChild.children?.length === 1 &&
+      firstChild.children[0]?.name === 'mo'
+
+    // Check if last child is mrow with CLOSE class containing mo
+    const isCloseWrapper =
+      lastChild.name === 'mrow' &&
+      lastChild.attribs?.['data-mjx-texclass'] === 'CLOSE' &&
+      lastChild.children?.length === 1 &&
+      lastChild.children[0]?.name === 'mo'
+
+    if (isOpenWrapper && isCloseWrapper) {
+      // Extract delimiter characters from the nested mo elements
+      const openChar = decodeHtmlEntities(getTextContent(firstChild.children[0]))
+      const closeChar = decodeHtmlEntities(getTextContent(lastChild.children[0]))
+
+      // Create m:d delimiter structure
+      const contentTarget = {
+        name: 'm:e',
+        type: 'tag',
+        attribs: {},
+        children: []
+      }
+
+      const delimElement = {
+        name: 'm:d',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:dPr',
+            type: 'tag',
+            attribs: {},
+            children: [
+              {
+                name: 'm:begChr',
+                type: 'tag',
+                attribs: { 'm:val': openChar },
+                children: []
+              },
+              {
+                name: 'm:endChr',
+                type: 'tag',
+                attribs: { 'm:val': closeChar },
+                children: []
+              }
+            ]
+          },
+          contentTarget
+        ]
+      }
+
+      targetParent.children.push(delimElement)
+
+      // Process inner children (skip first and last which are the delimiter wrappers)
+      const innerChildren = element.children.slice(1, -1)
+      if (innerChildren.length > 0) {
+        ancestors = [...ancestors]
+        ancestors.unshift(element)
+        for (let i = 0; i < innerChildren.length; i++) {
+          walker(
+            innerChildren[i],
+            contentTarget,
+            innerChildren[i - 1],
+            innerChildren[i + 1],
+            ancestors
+          )
+        }
+      }
+
+      // Return null to prevent default child processing
+      return null
+    }
+  }
+
+  // Check for empty mrow - fill with zero-width space to avoid empty <m:e/>
+  if (!element.children || element.children.length === 0) {
+    targetParent.children.push({
+      name: 'm:r',
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          name: 'm:t',
+          type: 'tag',
+          attribs: { 'xml:space': 'preserve' },
+          children: [{ type: 'text', data: UNICODE_SPACES.ZERO_WIDTH_SPACE }]
+        }
+      ]
+    })
+    return null
+  }
+
+  // Default behavior - ignore mrow wrapper
+  return targetParent
+}
+
+function mspace(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Get width attribute and convert to appropriate Unicode space
+  const width = element.attribs?.width
+  const spaceChar = width ? spaceValueToUnicode(width) : ' '
+
+  // Only add space if there's something to add
+  if (spaceChar) {
+    targetParent.children.push({
+      name: 'm:r',
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          name: 'm:t',
+          type: 'tag',
+          attribs: {
+            'xml:space': 'preserve'
+          },
+          children: [
+            {
+              type: 'text',
+              data: spaceChar
+            }
+          ]
+        }
+      ]
+    })
+  }
+}
+
+function msqrt(element, targetParent, previousSibling, nextSibling, ancestors) {
+  const targetElement = {
+    name: 'm:e',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  targetParent.children.push({
+    name: 'm:rad',
+    type: 'tag',
+    attribs: {},
+    children: [
+      {
+        name: 'm:radPr',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:degHide',
+            type: 'tag',
+            attribs: {
+              'm:val': 'on'
+            },
+            children: []
+          }
+        ]
+      },
+      {
+        name: 'm:deg',
+        type: 'tag',
+        attribs: {},
+        children: []
+      },
+      targetElement
+    ]
+  })
+  return targetElement
+}
+
+function mstyle(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Ignore as default behavior
+  return targetParent
+}
+
+function msub(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Subscript
+  if (element.children.length !== 2) {
+    // treat as mrow
+    return targetParent
+  }
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+  const base = element.children[0]
+  const subscript = element.children[1]
+
+  let topTarget
+  //
+  // m:nAry
+  //
+  // Conditions:
+  // 1. base text must be nary operator
+  // 2. no accents
+  const naryChar = getNary(base)
+  if (
+    naryChar &&
+    element.attribs?.accent?.toLowerCase() !== 'true' &&
+    element.attribs?.accentunder?.toLowerCase() !== 'true'
+  ) {
+    topTarget = getNaryTarget(naryChar, element, 'subSup', false, true)
+    element.isNary = true
+  } else {
+    const baseTarget = {
+      name: 'm:e',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    walker(base, baseTarget, false, false, ancestors)
+    topTarget = {
+      type: 'tag',
+      name: 'm:sSub',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:sSubPr',
+          attribs: {},
+          children: [
+            {
+              type: 'tag',
+              name: 'm:ctrlPr',
+              attribs: {},
+              children: []
+            }
+          ]
+        },
+        baseTarget
+      ]
+    }
+  }
+
+  const subscriptTarget = {
+    name: 'm:sub',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+
+  walker(subscript, subscriptTarget, false, false, ancestors)
+  topTarget.children.push(subscriptTarget)
+  if (element.isNary) {
+    topTarget.children.push({ type: 'tag', name: 'm:sup', attribs: {}, children: [] })
+    topTarget.children.push({ type: 'tag', name: 'm:e', attribs: {}, children: [] })
+  }
+  targetParent.children.push(topTarget)
+  // Don't iterate over children in the usual way.
+}
+
+function msubsup(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Sub + superscript
+  if (element.children.length !== 3) {
+    // treat as mrow
+    return targetParent
+  }
+
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+
+  const base = element.children[0]
+  const subscript = element.children[1]
+  const superscript = element.children[2]
+
+  let topTarget
+  //
+  // m:nAry
+  //
+  // Conditions:
+  // 1. base text must be nary operator
+  // 2. no accents
+  const naryChar = getNary(base)
+  if (
+    naryChar &&
+    element.attribs?.accent?.toLowerCase() !== 'true' &&
+    element.attribs?.accentunder?.toLowerCase() !== 'true'
+  ) {
+    topTarget = getNaryTarget(naryChar, element, 'subSup')
+    element.isNary = true
+  } else {
+    // fallback: m:sSubSup
+    const baseTarget = {
+      name: 'm:e',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+
+    walker(base, baseTarget, false, false, ancestors)
+    topTarget = {
+      type: 'tag',
+      name: 'm:sSubSup',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:sSubSupPr',
+          attribs: {},
+          children: [
+            {
+              type: 'tag',
+              name: 'm:ctrlPr',
+              attribs: {},
+              children: []
+            }
+          ]
+        },
+        baseTarget
+      ]
+    }
+  }
+
+  const subscriptTarget = {
+    name: 'm:sub',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  const superscriptTarget = {
+    name: 'm:sup',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  walker(subscript, subscriptTarget, false, false, ancestors)
+  walker(superscript, superscriptTarget, false, false, ancestors)
+  topTarget.children.push(subscriptTarget)
+  topTarget.children.push(superscriptTarget)
+  if (element.isNary) {
+    topTarget.children.push({ type: 'tag', name: 'm:e', attribs: {}, children: [] })
+  }
+  targetParent.children.push(topTarget)
+  // Don't iterate over children in the usual way.
+}
+
+function msup(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Superscript
+  if (element.children.length !== 2) {
+    // treat as mrow
+    return targetParent
+  }
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+  const base = element.children[0]
+  const superscript = element.children[1]
+
+  let topTarget
+  //
+  // m:nAry
+  //
+  // Conditions:
+  // 1. base text must be nary operator
+  // 2. no accents
+  const naryChar = getNary(base)
+  if (
+    naryChar &&
+    element.attribs?.accent?.toLowerCase() !== 'true' &&
+    element.attribs?.accentunder?.toLowerCase() !== 'true'
+  ) {
+    topTarget = getNaryTarget(naryChar, element, 'subSup', true)
+    element.isNary = true
+    topTarget.children.push({ type: 'tag', name: 'm:sub' })
+  } else {
+    const baseTarget = {
+      name: 'm:e',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    walker(base, baseTarget, false, false, ancestors)
+
+    topTarget = {
+      type: 'tag',
+      name: 'm:sSup',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:sSupPr',
+          attribs: {},
+          children: [
+            {
+              type: 'tag',
+              name: 'm:ctrlPr',
+              attribs: {},
+              children: []
+            }
+          ]
+        },
+        baseTarget
+      ]
+    }
+  }
+
+  const superscriptTarget = {
+    name: 'm:sup',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+
+  walker(superscript, superscriptTarget, false, false, ancestors)
+
+  topTarget.children.push(superscriptTarget)
+  if (element.isNary) {
+    topTarget.children.push({ type: 'tag', name: 'm:e', attribs: {}, children: [] })
+  }
+  targetParent.children.push(topTarget)
+  // Don't iterate over children in the usual way.
+}
+
+function mtable(element, targetParent, previousSibling, nextSibling, ancestors) {
+  const cellsPerRowCount = Math.max(...element.children.map((row) => row.children.length))
+
+  // Get column alignment from columnalign attribute
+  // Can be space-separated values like "right left" or "center center center"
+  const columnAlignAttr = element.attribs?.columnalign
+  let columnAlignments = []
+  if (columnAlignAttr) {
+    columnAlignments = columnAlignAttr.trim().split(/\s+/)
+  }
+
+  // Build m:mcs with proper column alignments
+  const mcsChildren = []
+  if (columnAlignments.length > 0) {
+    // Create individual m:mc for each column with its alignment
+    for (let i = 0; i < cellsPerRowCount; i++) {
+      // Use the alignment for this column, or default to center
+      const align = columnAlignments[i] || columnAlignments[columnAlignments.length - 1] || 'center'
+      const ommlAlign = align === 'right' ? 'right' : align === 'left' ? 'left' : 'center'
+      mcsChildren.push({
+        name: 'm:mc',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:mcPr',
+            type: 'tag',
+            attribs: {},
+            children: [
+              {
+                name: 'm:count',
+                type: 'tag',
+                attribs: { 'm:val': '1' },
+                children: []
+              },
+              {
+                name: 'm:mcJc',
+                type: 'tag',
+                attribs: { 'm:val': ommlAlign },
+                children: []
+              }
+            ]
+          }
+        ]
+      })
+    }
+  } else {
+    // Default: single m:mc for all columns with center alignment
+    mcsChildren.push({
+      name: 'm:mc',
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          name: 'm:mcPr',
+          type: 'tag',
+          attribs: {},
+          children: [
+            {
+              name: 'm:count',
+              type: 'tag',
+              attribs: { 'm:val': cellsPerRowCount.toString() },
+              children: []
+            },
+            {
+              name: 'm:mcJc',
+              type: 'tag',
+              attribs: { 'm:val': 'center' },
+              children: []
+            }
+          ]
+        }
+      ]
+    })
+  }
+
+  const targetElement = {
+    name: 'm:m',
+    type: 'tag',
+    attribs: {},
+    children: [
+      {
+        name: 'm:mPr',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:baseJc',
+            type: 'tag',
+            attribs: {
+              'm:val': 'center'
+            },
+            children: []
+          },
+          {
+            name: 'm:plcHide',
+            type: 'tag',
+            attribs: {
+              'm:val': 'on'
+            },
+            children: []
+          },
+          {
+            name: 'm:mcs',
+            type: 'tag',
+            attribs: {},
+            children: mcsChildren
+          }
+        ]
+      }
+    ]
+  }
+  targetParent.children.push(targetElement)
+  return targetElement
+}
+
+function mtd(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // table cell
+  const targetElement = {
+    name: 'm:e',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  targetParent.children.push(targetElement)
+  return targetElement
+}
+
+function mtr(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // table row
+  const targetElement = {
+    name: 'm:mr',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  targetParent.children.push(targetElement)
+  return targetElement
+}
+
+function munderover(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Munderover
+  if (element.children.length !== 3) {
+    // treat as mrow
+    return targetParent
+  }
+
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+
+  const base = element.children[0]
+  const underscript = element.children[1]
+  const overscript = element.children[2]
+
+  //
+  // m:nAry
+  //
+  // Conditions:
+  // 1. base text must be nary operator
+  // 2. no accents
+  const naryChar = getNary(base)
+  if (
+    naryChar &&
+    element.attributes?.accent?.toLowerCase() !== 'true' &&
+    element.attributes?.accentunder?.toLowerCase() !== 'true'
+  ) {
+    const topTarget = getNaryTarget(naryChar, element, 'undOvr')
+    element.isNary = true
+    const subscriptTarget = {
+      name: 'm:sub',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    const superscriptTarget = {
+      name: 'm:sup',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    walker(underscript, subscriptTarget, false, false, ancestors)
+    walker(overscript, superscriptTarget, false, false, ancestors)
+    topTarget.children.push(subscriptTarget)
+    topTarget.children.push(superscriptTarget)
+    topTarget.children.push({ type: 'tag', name: 'm:e', attribs: {}, children: [] })
+    targetParent.children.push(topTarget)
+    return
+  }
+
+  // Fallback: m:limUpp()m:limlow
+
+  const baseTarget = {
+    name: 'm:e',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+
+  walker(base, baseTarget, false, false, ancestors)
+
+  const underscriptTarget = {
+    name: 'm:lim',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  const overscriptTarget = {
+    name: 'm:lim',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+
+  walker(underscript, underscriptTarget, false, false, ancestors)
+  walker(overscript, overscriptTarget, false, false, ancestors)
+  targetParent.children.push({
+    type: 'tag',
+    name: 'm:limUpp',
+    attribs: {},
+    children: [
+      {
+        type: 'tag',
+        name: 'm:e',
+        attribs: {},
+        children: [
+          {
+            type: 'tag',
+            name: 'm:limLow',
+            attribs: {},
+            children: [baseTarget, underscriptTarget]
+          }
+        ]
+      },
+      overscriptTarget
+    ]
+  })
+  // Don't iterate over children in the usual way.
+}
+
+function getStyle(element, ancestors, previousStyle = {}) {
+  const elAttributes = element.attribs || {}
+  const color =
+    elAttributes.mathcolor ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.color
+    )?.attribs.color ||
+    ''
+  // const minsize = parseFloat(elAttributes.scriptminsize || ancestors.find(element => element.name === 'mstyle' && element.attribs && element.attribs.scriptminsize)?.attribs.scriptminsize || '8pt')
+  // const sizemultiplier = parseFloat(elAttributes.scriptsizemultiplier || ancestors.find(element => element.name === 'mstyle' && element.attribs && element.attribs.scriptsizemultiplier)?.attribs.scriptsizemultiplier || '0.71')
+  const size =
+    elAttributes.mathsize ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.mathsize
+    )?.attribs.mathsize ||
+    ''
+  const scriptlevel =
+    elAttributes.scriptlevel ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.scriptlevel
+    )?.attribs.scriptlevel ||
+    ''
+  const background =
+    elAttributes.mathbackground ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.mathbackground
+    )?.attribs.mathbackground ||
+    ''
+  let variant =
+    elAttributes.mathvariant ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.mathvariant
+    )?.attribs.mathvariant ||
+    ''
+  if (variant === 'b-i') {
+    variant = 'bold-italic'
+  }
+  const fontweight =
+    elAttributes.fontweight ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.fontweight
+    )?.attribs.fontweight ||
+    ''
+  if (fontweight === 'bold' && !['bold', 'bold-italic'].includes(variant)) {
+    if (variant.includes('italic')) {
+      variant = 'bold-italic'
+    } else {
+      variant = 'bold'
+    }
+  } else if (fontweight === 'normal' && ['bold', 'bold-italic'].includes(variant)) {
+    if (variant.includes('italic')) {
+      variant = 'italic'
+    } else {
+      variant = ''
+    }
+  }
+  const fontstyle =
+    elAttributes.fontstyle ||
+    ancestors.find(
+      (element) => element.name === 'mstyle' && element.attribs && element.attribs.fontstyle
+    )?.attribs.fontstyle ||
+    ''
+  if (fontstyle === 'italic' && !['italic', 'bold-italic'].includes(variant)) {
+    if (variant.includes('bold')) {
+      variant = 'bold-italic'
+    } else {
+      variant = 'italic'
+    }
+  } else if (fontstyle === 'normal' && ['italic', 'bold-italic'].includes(variant)) {
+    if (variant.includes('bold')) {
+      variant = 'bold'
+    } else {
+      variant = ''
+    }
+  }
+  // Override variant for some types
+  if (!elAttributes.mathvariant) {
+    const textContent = getTextContent(element)
+    if (
+      previousStyle.variant === '' &&
+      ((element.name === 'mi' && textContent.length > 1) ||
+        (element.name === 'mn' && !/^\d+\.\d+$/.test(textContent)))
+    ) {
+      variant = ''
+    } else if (
+      ['mi', 'mn', 'mo'].includes(element.name) &&
+      ['italic', 'bold-italic'].includes(previousStyle.variant)
+    ) {
+      if (fontweight === 'bold') {
+        variant = 'bold-italic'
+      } else {
+        variant = 'italic'
+      }
+    }
+  }
+
+  return {
+    color,
+    variant,
+    size,
+    scriptlevel,
+    background,
+    fontstyle
+  }
+}
+
+const STYLES = {
+  bold: 'b',
+  italic: 'i',
+  'bold-italic': 'bi'
+}
+
+function textContainer(element, targetParent, previousSibling, nextSibling, ancestors, textType) {
+  if (previousSibling.isNary) {
+    const previousSiblingTarget = targetParent.children[targetParent.children.length - 1]
+    targetParent = previousSiblingTarget.children[previousSiblingTarget.children.length - 1]
+  }
+
+  const hasMglyphChild = element.children?.find((element) => element.name === 'mglyph')
+  const style = getStyle(element, ancestors, previousSibling?.style)
+  element.style = style // Add it to element to make it comparable
+  element.hasMglyphChild = hasMglyphChild
+  const styleSame =
+    Object.keys(style).every((key) => {
+      const previousStyle = previousSibling?.style
+      return previousStyle && style[key] === previousStyle[key]
+    }) && previousSibling?.hasMglyphChild === hasMglyphChild
+  const sameGroup = // Only group mtexts or mi, mn, mo with oneanother.
+    textType === previousSibling?.name ||
+    (['mi', 'mn', 'mo'].includes(textType) && ['mi', 'mn', 'mo'].includes(previousSibling?.name))
+  let targetElement
+  if (sameGroup && styleSame && !hasMglyphChild) {
+    const rElement = targetParent.children[targetParent.children.length - 1]
+    targetElement = rElement.children[rElement.children.length - 1]
+  } else {
+    const rElement = {
+      name: 'm:r',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+
+    if (style.variant) {
+      const wrPr = {
+        name: 'w:rPr',
+        type: 'tag',
+        attribs: {},
+        children: []
+      }
+      if (style.variant.includes('bold')) {
+        wrPr.children.push({ name: 'w:b', type: 'tag', attribs: {}, children: [] })
+      }
+      if (style.variant.includes('italic')) {
+        wrPr.children.push({ name: 'w:i', type: 'tag', attribs: {}, children: [] })
+      }
+      rElement.children.push(wrPr)
+      const mrPr = {
+        name: 'm:rPr',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:nor',
+            type: 'tag',
+            attribs: {},
+            children: []
+          }
+        ]
+      }
+      if (style.variant !== 'italic') {
+        mrPr.children.push({
+          name: 'm:sty',
+          type: 'tag',
+          attribs: {
+            'm:val': STYLES[style.variant]
+          },
+          children: []
+        })
+      }
+      rElement.children.push(mrPr)
+    } else if (hasMglyphChild || textType === 'mtext') {
+      rElement.children.push({
+        name: 'm:rPr',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:nor',
+            type: 'tag',
+            attribs: {},
+            children: []
+          }
+        ]
+      })
+    } else if (style.fontstyle === 'normal' || (textType === 'ms' && style.fontstyle === '')) {
+      rElement.children.push({
+        name: 'm:rPr',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:sty',
+            type: 'tag',
+            attribs: { 'm:val': 'p' },
+            children: []
+          }
+        ]
+      })
+    }
+
+    targetElement = {
+      name: 'm:t',
+      type: 'tag',
+      attribs: {
+        'xml:space': 'preserve'
+      },
+      children: []
+    }
+    rElement.children.push(targetElement)
+    targetParent.children.push(rElement)
+  }
+  return targetElement
+}
+
+function mtext(element, targetParent, previousSibling, nextSibling, ancestors) {
+  return textContainer(element, targetParent, previousSibling, nextSibling, ancestors, 'mtext')
+}
+
+function mi(element, targetParent, previousSibling, nextSibling, ancestors) {
+  return textContainer(element, targetParent, previousSibling, nextSibling, ancestors, 'mi')
+}
+
+function mn(element, targetParent, previousSibling, nextSibling, ancestors) {
+  return textContainer(element, targetParent, previousSibling, nextSibling, ancestors, 'mn')
+}
+
+function mo(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Check for invisible operators that should be converted to thin space
+  const textContent = decodeHtmlEntities(getTextContent(element))
+  // U+2061 is "function application" - used after \log, \sin, \cos, etc.
+  if (textContent === '\u2061') {
+    targetParent.children.push({
+      name: 'm:r',
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          name: 'm:t',
+          type: 'tag',
+          attribs: { 'xml:space': 'preserve' },
+          children: [{ type: 'text', data: UNICODE_SPACES.THIN_SPACE }]
+        }
+      ]
+    })
+    return null
+  }
+
+  // Handle lspace attribute - add space before operator
+  const lspace = element.attribs?.lspace
+  if (lspace) {
+    const spaceChar = spaceValueToUnicode(lspace)
+    if (spaceChar) {
+      targetParent.children.push({
+        name: 'm:r',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:t',
+            type: 'tag',
+            attribs: { 'xml:space': 'preserve' },
+            children: [{ type: 'text', data: spaceChar }]
+          }
+        ]
+      })
+    }
+  }
+
+  // Process the operator itself
+  const result = textContainer(element, targetParent, previousSibling, nextSibling, ancestors, 'mo')
+
+  // Handle rspace attribute - add space after operator
+  const rspace = element.attribs?.rspace
+  if (rspace) {
+    const spaceChar = spaceValueToUnicode(rspace)
+    if (spaceChar) {
+      targetParent.children.push({
+        name: 'm:r',
+        type: 'tag',
+        attribs: {},
+        children: [
+          {
+            name: 'm:t',
+            type: 'tag',
+            attribs: { 'xml:space': 'preserve' },
+            children: [{ type: 'text', data: spaceChar }]
+          }
+        ]
+      })
+    }
+  }
+
+  // Handle movablelimits operators (sup, inf, max, min, lim, etc.)
+  // These operators need a thin space after them when followed by mi
+  if (element.attribs?.movablelimits === 'true' && nextSibling?.name === 'mi') {
+    targetParent.children.push({
+      name: 'm:r',
+      type: 'tag',
+      attribs: {},
+      children: [
+        {
+          name: 'm:t',
+          type: 'tag',
+          attribs: { 'xml:space': 'preserve' },
+          children: [{ type: 'text', data: UNICODE_SPACES.THIN_SPACE }]
+        }
+      ]
+    })
+  }
+
+  return result
+}
+
+function ms(element, targetParent, previousSibling, nextSibling, ancestors) {
+  return textContainer(element, targetParent, previousSibling, nextSibling, ancestors, 'ms')
+}
+
+const UPPER_COMBINATION = {
+  '\u2190': '\u20D6', // arrow left
+  '\u27F5': '\u20D6', // arrow left, long
+  '\u2192': '\u20D7', // arrow right
+  '\u27F6': '\u20D7', // arrow right, long
+  '\u00B4': '\u0301', // accute
+  '\u02DD': '\u030B', // accute, double
+  '\u02D8': '\u0306', // breve
+  ˇ: '\u030C', // caron
+  '\u00B8': '\u0312', // cedilla
+  '\u005E': '\u0302', // circumflex accent
+  '\u00A8': '\u0308', // diaresis
+  '\u02D9': '\u0307', // dot above
+  '\u0060': '\u0300', // grave accent
+  '\u002D': '\u0305', // hyphen -> overline
+  '\u00AF': '\u0305', // macron
+  '\u2212': '\u0305', // minus -> overline
+  '\u002E': '\u0307', // period -> dot above
+  '\u007E': '\u0303', // tilde
+  '\u02DC': '\u0303', // small tilde
+  '\u02DA': '\u030A', // ring above (mathring)
+  '\u20DB': '\u20DB', // combining three dots above (dddot) - already combining
+}
+
+function underOrOver(element, targetParent, previousSibling, nextSibling, ancestors, direction) {
+  // Munder/Mover
+
+  if (element.children.length !== 2) {
+    // treat as mrow
+    return targetParent
+  }
+
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+
+  const base = element.children[0]
+  const script = element.children[1]
+
+  // Munder/Mover can be translated to ooml in different ways.
+
+  // First we check for m:nAry.
+  //
+  // m:nAry
+  //
+  // Conditions:
+  // 1. base text must be nary operator
+  // 2. no accents
+  const naryChar = getNary(base)
+
+  if (
+    naryChar &&
+    element.attribs?.accent?.toLowerCase() !== 'true' &&
+    element.attribs?.accentunder?.toLowerCase() !== 'true'
+  ) {
+    const topTarget = getNaryTarget(
+      naryChar,
+      element,
+      'undOvr',
+      direction === 'over',
+      direction === 'under'
+    )
+    element.isNary = true
+
+    const subscriptTarget = {
+      name: 'm:sub',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    const superscriptTarget = {
+      name: 'm:sup',
+      type: 'tag',
+      attribs: {},
+      children: []
+    }
+    walker(
+      script,
+      direction === 'under' ? subscriptTarget : superscriptTarget,
+      false,
+      false,
+      ancestors
+    )
+    topTarget.children.push(subscriptTarget)
+    topTarget.children.push(superscriptTarget)
+    topTarget.children.push({ type: 'tag', name: 'm:e', attribs: {}, children: [] })
+    targetParent.children.push(topTarget)
+    return
+  }
+
+  const scriptText = decodeHtmlEntities(getTextContent(script))
+
+  const baseTarget = {
+    name: 'm:e',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+  walker(base, baseTarget, false, false, ancestors)
+
+  //
+  // m:bar
+  //
+  // Then we check whether it should be an m:bar.
+  // This happens if:
+  // 1. The script text is a single character that corresponds to
+  //    underbar (\u0332, \u005F) or overbar (\u0305, \u00AF, \u2015, \u203E)
+  // 2. The type of the script element is mo.
+  const UNDERBAR_CHARS = ['\u0332', '\u005F', '\u2581', '\u23AF', '\u2015', '\u203E']
+  const OVERBAR_CHARS = ['\u0305', '\u00AF', '\u2015', '\u203E', '\u2594', '\u23AF']
+  if (
+    (direction === 'under' && script.name === 'mo' && UNDERBAR_CHARS.includes(scriptText)) ||
+    (direction === 'over' && script.name === 'mo' && OVERBAR_CHARS.includes(scriptText))
+  ) {
+    // m:bar - simple structure that stretches to content width
+    targetParent.children.push({
+      type: 'tag',
+      name: 'm:bar',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:barPr',
+          attribs: {},
+          children: [
+            {
+              type: 'tag',
+              name: 'm:pos',
+              attribs: {
+                'm:val': direction === 'under' ? 'bot' : 'top'
+              },
+              children: []
+            }
+          ]
+        },
+        baseTarget
+      ]
+    })
+    return
+  }
+
+  // m:acc
+  //
+  // Next we try to see if it is an m:acc. This is the case if:
+  // 1. The scriptText is 0-1 characters long.
+  // 2. The script is an mo-element
+  // 3. The accent is set OR the character is in UPPER_COMBINATION (for widehat/widetilde)
+  //
+  // For \widehat and \widetilde, MathJax doesn't set accent="true" but uses ^ and ~.
+  // Word's m:acc will automatically stretch the accent character to fit the base width.
+  const isAccentChar = scriptText in UPPER_COMBINATION
+  if (
+    (direction === 'under' &&
+      element.attribs?.accentunder?.toLowerCase() === 'true' &&
+      script.name === 'mo' &&
+      scriptText.length < 2) ||
+    (direction === 'over' &&
+      (element.attribs?.accent?.toLowerCase() === 'true' || isAccentChar) &&
+      script.name === 'mo' &&
+      scriptText.length < 2)
+  ) {
+    // m:acc
+    targetParent.children.push({
+      type: 'tag',
+      name: 'm:acc',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:accPr',
+          attribs: {},
+          children: [
+            {
+              type: 'tag',
+              name: 'm:chr',
+              attribs: {
+                'm:val': UPPER_COMBINATION[scriptText] || scriptText
+              },
+              children: []
+            }
+          ]
+        },
+        baseTarget
+      ]
+    })
+    return
+  }
+  // m:groupChr
+  //
+  // Now we try m:groupChr. Conditions are:
+  // 1. Base is an 'mrow' and script is an 'mo'.
+  // 2. Script length is 1.
+  // 3. No accent
+  // 4. Character must be stretchable (not ^ or ~ which should use m:acc)
+  //
+  // Characters that Word can stretch in groupChr:
+  // - U+23DE ⏞ TOP CURLY BRACKET (overbrace)
+  // - U+23DF ⏟ BOTTOM CURLY BRACKET (underbrace)
+  // - U+2192 → RIGHTWARDS ARROW
+  // - U+2190 ← LEFTWARDS ARROW
+  // - U+2194 ↔ LEFT RIGHT ARROW
+  // - Horizontal line characters (for overline/underline - but those use m:bar)
+  const GROUPCHR_STRETCHABLE = new Set([
+    '\u23DE', // ⏞ TOP CURLY BRACKET
+    '\u23DF', // ⏟ BOTTOM CURLY BRACKET
+    '\u2192', // → RIGHTWARDS ARROW
+    '\u2190', // ← LEFTWARDS ARROW
+    '\u2194', // ↔ LEFT RIGHT ARROW
+    '\u21D2', // ⇒ RIGHTWARDS DOUBLE ARROW
+    '\u21D0', // ⇐ LEFTWARDS DOUBLE ARROW
+    '\u21D4', // ⇔ LEFT RIGHT DOUBLE ARROW
+    '\u23DC', // ⏜ TOP PARENTHESIS
+    '\u23DD', // ⏝ BOTTOM PARENTHESIS
+  ])
+
+  if (
+    element.attribs?.accent?.toLowerCase() !== 'true' &&
+    element.attribs?.accentunder?.toLowerCase() !== 'true' &&
+    script.name === 'mo' &&
+    base.name === 'mrow' &&
+    scriptText.length === 1 &&
+    GROUPCHR_STRETCHABLE.has(scriptText)
+  ) {
+    targetParent.children.push({
+      type: 'tag',
+      name: 'm:groupChr',
+      attribs: {},
+      children: [
+        {
+          type: 'tag',
+          name: 'm:groupChrPr',
+          attribs: {},
+          children: [
+            {
+              type: 'tag',
+              name: 'm:chr',
+              attribs: { 'm:val': scriptText },
+              children: []
+            },
+            {
+              type: 'tag',
+              name: 'm:pos',
+              attribs: { 'm:val': direction === 'under' ? 'bot' : 'top' },
+              children: []
+            },
+            {
+              type: 'tag',
+              name: 'm:vertJc',
+              attribs: { 'm:val': direction === 'under' ? 'top' : 'bot' },
+              children: []
+            }
+          ]
+        },
+        baseTarget
+      ]
+    })
+    return
+  }
+  // Fallback: m:lim
+
+  const scriptTarget = {
+    name: 'm:lim',
+    type: 'tag',
+    attribs: {},
+    children: []
+  }
+
+  walker(script, scriptTarget, false, false, ancestors)
+  targetParent.children.push({
+    type: 'tag',
+    name: direction === 'under' ? 'm:limLow' : 'm:limUpp',
+    attribs: {},
+    children: [baseTarget, scriptTarget]
+  })
+  // Don't iterate over children in the usual way.
+}
+
+function munder(element, targetParent, previousSibling, nextSibling, ancestors) {
+  return underOrOver(element, targetParent, previousSibling, nextSibling, ancestors, 'under')
+}
+
+function mover(element, targetParent, previousSibling, nextSibling, ancestors) {
+  return underOrOver(element, targetParent, previousSibling, nextSibling, ancestors, 'over')
+}
+
+function mroot(element, targetParent, previousSibling, nextSibling, ancestors) {
+  // Root
+  if (element.children.length !== 2) {
+    // treat as mrow
+    return targetParent
+  }
+  ancestors = [...ancestors]
+  ancestors.unshift(element)
+  const base = element.children[0]
+  const root = element.children[1]
+
+  const baseTarget = {
+    type: 'tag',
+    name: 'm:e',
+    attribs: {},
+    children: []
+  }
+  walker(base, baseTarget, false, false, ancestors)
+
+  const rootTarget = {
+    type: 'tag',
+    name: 'm:deg',
+    attribs: {},
+    children: []
+  }
+  walker(root, rootTarget, false, false, ancestors)
+
+  const rootText = getTextContent(root)
+
+  targetParent.children.push({
+    type: 'tag',
+    name: 'm:rad',
+    attribs: {},
+    children: [
+      {
+        type: 'tag',
+        name: 'm:radPr',
+        attribs: {},
+        children: [
+          {
+            type: 'tag',
+            name: 'm:degHide',
+            attribs: { 'm:val': rootText.length ? 'off' : 'on' },
+            children: []
+          }
+        ]
+      },
+      rootTarget,
+      baseTarget
+    ]
+  })
+}
+
+function text(element, targetParent, previousSibling, nextSibling, ancestors) {
+  let text = element.data.replace(/[\u2062]|[\u200B]/g, '')
+  if (ancestors.find((element) => ['mi', 'mn', 'mo'].includes(element.name))) {
+    text = text.replace(/\s/g, '')
+  } else {
+    const ms = ancestors.find((element) => element.name === 'ms')
+    if (ms) {
+      text = (ms.attribs?.lquote || '"') + text + (ms.attribs?.rquote || '"')
+    }
+  }
+  if (text.length) {
+    if (
+      targetParent.children.length &&
+      targetParent.children[targetParent.children.length - 1].type === 'text'
+    ) {
+      targetParent.children[targetParent.children.length - 1].data += text
+    } else {
+      targetParent.children.push({
+        type: 'text',
+        data: text
+      })
+    }
+  }
+  return targetParent
+}
+
+const mathmlHandlers = /*#__PURE__*/ Object.freeze({
+  __proto__: null,
+  math: math,
+  menclose: menclose,
+  mfrac: mfrac,
+  mglyph: mglyph,
+  mi: mi,
+  mmultiscripts: mmultiscripts,
+  mn: mn,
+  mo: mo,
+  mover: mover,
+  mroot: mroot,
+  mrow: mrow,
+  ms: ms,
+  mspace: mspace,
+  msqrt: msqrt,
+  mstyle: mstyle,
+  msub: msub,
+  msubsup: msubsup,
+  msup: msup,
+  mtable: mtable,
+  mtd: mtd,
+  mtext: mtext,
+  mtr: mtr,
+  munder: munder,
+  munderover: munderover,
+  semantics: semantics,
+  text: text
+})
+
+function walker(
+  element,
+  targetParent,
+  previousSibling = false,
+  nextSibling = false,
+  ancestors = []
+) {
+  if (
+    !previousSibling &&
+    ['m:deg', 'm:den', 'm:e', 'm:fName', 'm:lim', 'm:num', 'm:sub', 'm:sup'].includes(
+      targetParent.name
+    )
+  ) {
+    // We are walking through the first element within one of the
+    // elements where an <m:argPr> might occur. The <m:argPr> can specify
+    // the scriptlevel, but it only makes sense if there is some content.
+    // The fact that we are here means that there is at least one content item.
+    // So we will check whether to add the m:rPr.
+    // For possible parent types, see
+    // https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.math.argumentproperties?view=openxml-2.8.1#remarks
+    addScriptlevel(targetParent, ancestors)
+  }
+  let targetElement
+  const nameOrType = element.name || element.type
+  if (mathmlHandlers[nameOrType]) {
+    targetElement = mathmlHandlers[nameOrType](
+      element,
+      targetParent,
+      previousSibling,
+      nextSibling,
+      ancestors
+    )
+  } else {
+    if (nameOrType && nameOrType !== 'root') {
+      console.warn(`Type not supported: ${nameOrType}`)
+    }
+
+    targetElement = targetParent
+  }
+
+  if (!targetElement) {
+    // Target element hasn't been assigned, so don't handle children.
+    return
+  }
+  if (element.children?.length) {
+    ancestors = [...ancestors]
+    ancestors.unshift(element)
+    for (let i = 0; i < element.children.length; i++) {
+      walker(
+        element.children[i],
+        targetElement,
+        element.children[i - 1],
+        element.children[i + 1],
+        ancestors
+      )
+    }
+  }
+}
+
+class MML2OMML {
+  constructor(mmlString, options) {
+    this.inString = mmlString
+    this.inXML = parse(mmlString, options)
+    this.outXML = false
+    this.outString = false
+  }
+
+  run() {
+    const outXML = {}
+    walker({ children: this.inXML, type: 'root' }, outXML)
+    this.outXML = outXML
+  }
+
+  getResult() {
+    this.outString = stringifyDoc([this.outXML])
+    return this.outString
+  }
+}
+
+const mml2omml = (mmlString, options) => {
+  const converter = new MML2OMML(mmlString, options)
+  converter.run()
+  return converter.getResult()
+}
+
+export { mml2omml }
+//# sourceMappingURL=index.esm.js.map

--- a/markdown-sheet/src/lib/docx/table-merge-utils.ts
+++ b/markdown-sheet/src/lib/docx/table-merge-utils.ts
@@ -1,0 +1,340 @@
+/**
+ * Table Merge Utilities
+ * 
+ * Provides functions to calculate and apply vertical cell merging
+ * for tables with empty cells.
+ * 
+ * Uses table-structure-analyzer to detect table types and determine
+ * which columns should have cells merged.
+ */
+
+import { 
+  analyzeTableStructure, 
+  mightNeedAnalysis,
+  type TableAnalysisResult 
+} from './table-structure-analyzer';
+
+/**
+ * Merge information for a single cell
+ */
+export interface CellMergeInfo {
+  /** Number of rows this cell spans (1 = no merge) */
+  rowspan: number;
+  /** Number of columns this cell spans (1 = no merge) */
+  colspan: number;
+  /** Whether this cell should be rendered (false = merged into cell above/left) */
+  shouldRender: boolean;
+}
+
+/**
+ * Generic cell content interface
+ */
+export interface CellContent {
+  /** Text content of the cell */
+  text: string;
+  /** Original node/element (for reference) */
+  node?: unknown;
+}
+
+/**
+ * Check if a cell is considered empty
+ * @param cell - Cell content to check
+ * @returns true if the cell is empty
+ */
+export function isCellEmpty(cell: CellContent): boolean {
+  if (!cell.text) return true;
+  return cell.text.trim() === '';
+}
+
+/**
+ * Check if a cell content string is empty
+ * @param text - Text content to check
+ * @returns true if empty or whitespace only
+ */
+export function isTextEmpty(text: string | null | undefined): boolean {
+  if (!text) return true;
+  return text.trim() === '';
+}
+
+/**
+ * Calculate merge information for a table's data rows.
+ * 
+ * This function uses table structure analysis to determine:
+ * - Whether merging should be applied at all
+ * - Which columns are tree columns (eligible for merge)
+ * - Which rows are group headers (merge boundaries)
+ * 
+ * Only tree-structure columns have empty cells merged.
+ * Group header rows act as merge boundaries.
+ * 
+ * @param rows - 2D array of cell contents (data rows only, excluding header)
+ * @returns 2D array of merge information matching the input structure
+ * 
+ * @example
+ * ```
+ * const rows = [
+ *   [{ text: 'A' }, { text: 'B' }],
+ *   [{ text: '' },  { text: 'C' }],
+ *   [{ text: '' },  { text: '' }],
+ * ];
+ * const mergeInfo = calculateMergeInfo(rows);
+ * // Result depends on structure analysis
+ * ```
+ */
+export function calculateMergeInfo(rows: CellContent[][]): CellMergeInfo[][] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const rowCount = rows.length;
+  const colCount = rows[0]?.length || 0;
+
+  // Initialize merge info with defaults
+  const mergeInfo: CellMergeInfo[][] = rows.map(row =>
+    row.map(() => ({ rowspan: 1, colspan: 1, shouldRender: true }))
+  );
+
+  // Convert to string matrix for analysis
+  const stringMatrix = rows.map(row => row.map(cell => cell.text || ''));
+  
+  // Quick check: if no empty cells, no merge needed
+  if (!mightNeedAnalysis(stringMatrix)) {
+    return mergeInfo;
+  }
+
+  // Analyze table structure
+  const analysis = analyzeTableStructure(stringMatrix);
+  
+  // If table shouldn't be merged, return default (no merge)
+  if (!analysis.shouldMerge) {
+    return mergeInfo;
+  }
+
+  // Get tree columns and group header rows
+  const treeColumns = new Set(analysis.tree.columns);
+  const groupHeaderRows = new Set(analysis.groupHeaders.rows);
+
+  // Process each tree column independently
+  for (const col of treeColumns) {
+    if (col >= colCount) continue;
+    
+    // Track the current "anchor" cell that empty cells merge into
+    let anchorRow = -1;
+
+    for (let row = 0; row < rowCount; row++) {
+      // Group header row: reset anchor, don't merge
+      if (groupHeaderRows.has(row)) {
+        anchorRow = -1;
+        continue;
+      }
+      
+      const cell = rows[row]?.[col];
+      
+      if (!cell || isCellEmpty(cell)) {
+        // Empty cell: merge into anchor (if anchor exists)
+        if (anchorRow >= 0 && row > anchorRow) {
+          mergeInfo[row][col].shouldRender = false;
+          mergeInfo[anchorRow][col].rowspan = row - anchorRow + 1;
+        }
+      } else {
+        // Non-empty cell: this becomes the new anchor
+        anchorRow = row;
+      }
+    }
+  }
+
+  return mergeInfo;
+}
+
+/**
+ * Calculate merge information with analysis result returned.
+ * Useful when caller needs to know the table structure.
+ * 
+ * @param rows - 2D array of cell contents (data rows only, excluding header)
+ * @returns Merge information and analysis result
+ */
+export function calculateMergeInfoWithAnalysis(rows: CellContent[][]): {
+  mergeInfo: CellMergeInfo[][];
+  analysis: TableAnalysisResult | null;
+} {
+  if (rows.length === 0) {
+    return { mergeInfo: [], analysis: null };
+  }
+
+  const rowCount = rows.length;
+  const colCount = rows[0]?.length || 0;
+
+  // Initialize merge info with defaults
+  const mergeInfo: CellMergeInfo[][] = rows.map(row =>
+    row.map(() => ({ rowspan: 1, colspan: 1, shouldRender: true }))
+  );
+
+  // Convert to string matrix for analysis
+  const stringMatrix = rows.map(row => row.map(cell => cell.text || ''));
+  
+  // Quick check: if no empty cells, no merge needed
+  if (!mightNeedAnalysis(stringMatrix)) {
+    return { mergeInfo, analysis: null };
+  }
+
+  // Analyze table structure
+  const analysis = analyzeTableStructure(stringMatrix);
+  
+  // If table shouldn't be merged, return default (no merge)
+  if (!analysis.shouldMerge) {
+    return { mergeInfo, analysis };
+  }
+
+  // Get tree columns and group header rows
+  const treeColumns = new Set(analysis.tree.columns);
+  const groupHeaderRows = new Set(analysis.groupHeaders.rows);
+
+  // Process group header rows for horizontal merge (colspan)
+  for (const row of groupHeaderRows) {
+    if (row >= rowCount) continue;
+    
+    // Find the first non-empty cell and merge all trailing empty cells
+    let anchorCol = -1;
+    for (let col = 0; col < colCount; col++) {
+      const cell = rows[row]?.[col];
+      const isEmpty = !cell || isCellEmpty(cell);
+      
+      if (!isEmpty) {
+        // If we had a previous anchor, finish its colspan
+        if (anchorCol >= 0 && col > anchorCol + 1) {
+          mergeInfo[row][anchorCol].colspan = col - anchorCol;
+        }
+        anchorCol = col;
+      } else if (anchorCol >= 0) {
+        // Empty cell after anchor: mark as not rendered (merged left)
+        mergeInfo[row][col].shouldRender = false;
+      }
+    }
+    // Handle trailing empty cells
+    if (anchorCol >= 0 && anchorCol < colCount - 1) {
+      // Check if all remaining cells are empty
+      let allEmpty = true;
+      for (let col = anchorCol + 1; col < colCount; col++) {
+        const cell = rows[row]?.[col];
+        if (cell && !isCellEmpty(cell)) {
+          allEmpty = false;
+          break;
+        }
+      }
+      if (allEmpty) {
+        mergeInfo[row][anchorCol].colspan = colCount - anchorCol;
+      }
+    }
+  }
+
+  // Process each tree column independently for vertical merge (rowspan)
+  for (const col of treeColumns) {
+    if (col >= colCount) continue;
+    
+    let anchorRow = -1;
+
+    for (let row = 0; row < rowCount; row++) {
+      if (groupHeaderRows.has(row)) {
+        anchorRow = -1;
+        continue;
+      }
+      
+      const cell = rows[row]?.[col];
+      
+      if (!cell || isCellEmpty(cell)) {
+        if (anchorRow >= 0 && row > anchorRow) {
+          mergeInfo[row][col].shouldRender = false;
+          mergeInfo[anchorRow][col].rowspan = row - anchorRow + 1;
+        }
+      } else {
+        anchorRow = row;
+      }
+    }
+  }
+
+  return { mergeInfo, analysis };
+}
+
+/**
+ * Calculate merge information from a simple string matrix.
+ * Convenience wrapper for calculateMergeInfo.
+ * 
+ * @param rows - 2D array of string contents
+ * @returns 2D array of merge information
+ */
+export function calculateMergeInfoFromStrings(rows: string[][]): CellMergeInfo[][] {
+  const cellRows: CellContent[][] = rows.map(row =>
+    row.map(text => ({ text }))
+  );
+  return calculateMergeInfo(cellRows);
+}
+
+/**
+ * Calculate merge information from strings with analysis result.
+ * 
+ * @param rows - 2D array of string contents
+ * @returns Merge information and analysis result
+ */
+export function calculateMergeInfoFromStringsWithAnalysis(rows: string[][]): {
+  mergeInfo: CellMergeInfo[][];
+  analysis: TableAnalysisResult | null;
+} {
+  const cellRows: CellContent[][] = rows.map(row =>
+    row.map(text => ({ text }))
+  );
+  return calculateMergeInfoWithAnalysis(cellRows);
+}
+
+/**
+ * Extract text content from HAST table cell element
+ * @param cell - HAST element node
+ * @returns Text content of the cell
+ */
+export function extractTextFromHastCell(cell: unknown): string {
+  if (!cell || typeof cell !== 'object') return '';
+  
+  const node = cell as { children?: unknown[]; value?: string; type?: string };
+  
+  // Direct text value
+  if (node.type === 'text' && typeof node.value === 'string') {
+    return node.value;
+  }
+  
+  // Recursively extract from children
+  if (Array.isArray(node.children)) {
+    return node.children
+      .map(child => extractTextFromHastCell(child))
+      .join('');
+  }
+  
+  return '';
+}
+
+/**
+ * Extract text content from MDAST/DOCX AST table cell node
+ * @param cell - AST node
+ * @returns Text content of the cell
+ */
+export function extractTextFromAstCell(cell: unknown): string {
+  if (!cell || typeof cell !== 'object') return '';
+  
+  const node = cell as { 
+    children?: unknown[]; 
+    value?: string; 
+    type?: string;
+  };
+  
+  // Direct text value
+  if (node.type === 'text' && typeof node.value === 'string') {
+    return node.value;
+  }
+  
+  // Recursively extract from children
+  if (Array.isArray(node.children)) {
+    return node.children
+      .map(child => extractTextFromAstCell(child))
+      .join('');
+  }
+  
+  return '';
+}

--- a/markdown-sheet/src/lib/docx/table-structure-analyzer.ts
+++ b/markdown-sheet/src/lib/docx/table-structure-analyzer.ts
@@ -1,0 +1,561 @@
+/**
+ * Table Structure Analyzer
+ * 
+ * Analyzes table structure to determine:
+ * 1. Whether it's a tree-structured table (hierarchical data)
+ * 2. Which rows are group headers (section separators)
+ * 3. Which columns participate in the tree hierarchy
+ * 4. Overall table type classification
+ * 
+ * This information is used to decide whether and how to merge empty cells.
+ */
+
+// ============================================================================
+// Types and Interfaces
+// ============================================================================
+
+/**
+ * Table structure type classification
+ */
+export type TableType = 
+  | 'tree'        // Hierarchical/tree structure - should merge
+  | 'grouped'     // Has group headers but not strictly tree - partial merge
+  | 'sparse'      // Random empty cells - should NOT merge
+  | 'comparison'  // Feature comparison table - should NOT merge
+  | 'normal';     // Regular table, no special structure
+
+/**
+ * Comprehensive table structure analysis result
+ */
+export interface TableAnalysisResult {
+  /** Classified table type */
+  tableType: TableType;
+  
+  /** Whether the table should have cells merged */
+  shouldMerge: boolean;
+  
+  /** Tree structure specific results (if applicable) */
+  tree: {
+    /** Whether the table is a valid tree structure */
+    isTree: boolean;
+    /** Number of columns that participate in tree hierarchy */
+    columnCount: number;
+    /** Indices of tree columns (from left) */
+    columns: number[];
+    /** Tree structure confidence score (0-1) */
+    score: number;
+  };
+  
+  /** Group header detection results */
+  groupHeaders: {
+    /** Indices of rows that are group headers */
+    rows: number[];
+    /** Whether the table uses group header pattern */
+    hasGroupHeaders: boolean;
+  };
+  
+  /** Basic statistics */
+  stats: {
+    totalRows: number;
+    totalCols: number;
+    emptyCount: number;
+    emptyRatio: number;
+  };
+}
+
+/**
+ * Internal row analysis result
+ */
+interface RowAnalysis {
+  rowIndex: number;
+  nonEmptyCount: number;
+  lastNonEmptyCol: number;
+  emptyPrefix: number;
+  isGroupHeader: boolean;
+  isValidTreeRow: boolean;
+  isCompletelyEmpty: boolean;
+  hasGap: boolean;  // non-empty → empty → non-empty pattern in leftmost columns
+  gapStartCol: number;  // Column where gap starts (-1 if no gap)
+}
+
+/**
+ * Internal column analysis result
+ */
+interface ColumnAnalysis {
+  colIndex: number;
+  segmentCount: number;
+  maxSegmentLength: number;
+  hasMultiRowSegment: boolean;
+  isTreeColumn: boolean;
+}
+
+/**
+ * Merge segment: anchor + consecutive empty cells
+ */
+interface MergeSegment {
+  anchorRow: number;
+  length: number;
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Check if a cell value is empty
+ */
+function isEmpty(value: string | null | undefined): boolean {
+  if (value == null) return true;
+  return value.trim() === '';
+}
+
+/**
+ * Check if a value is a marker symbol (used in comparison tables)
+ * Common markers: ✓, ✗, ×, ○, ●, √, -, etc.
+ */
+function isMarkerSymbol(value: string | null | undefined): boolean {
+  if (value == null) return false;
+  const trimmed = value.trim();
+  return /^[✓✗×○●√\-+*·•◦▪▫☐☑☒✔✕✖⬤◯]{1,3}$/.test(trimmed);
+}
+
+// ============================================================================
+// Row Analysis
+// ============================================================================
+
+/**
+ * Analyze a single row for structure patterns
+ */
+function analyzeRow(row: string[], rowIndex: number, totalCols: number): RowAnalysis {
+  let emptyPrefix = 0;
+  let nonEmptyCount = 0;
+  let lastNonEmptyCol = -1;
+  
+  let seenNonEmpty = false;
+  let seenEmptyAfterNonEmpty = false;
+  let hasGap = false;
+  let gapStartCol = -1;
+  
+  for (let col = 0; col < totalCols; col++) {
+    const cellEmpty = isEmpty(row[col]);
+    
+    if (cellEmpty) {
+      if (!seenNonEmpty) {
+        emptyPrefix++;
+      } else {
+        seenEmptyAfterNonEmpty = true;
+        if (gapStartCol === -1) {
+          gapStartCol = col;
+        }
+      }
+    } else {
+      nonEmptyCount++;
+      lastNonEmptyCol = col;
+      if (seenEmptyAfterNonEmpty) {
+        hasGap = true;
+      }
+      seenNonEmpty = true;
+    }
+  }
+  
+  const isCompletelyEmpty = nonEmptyCount === 0;
+  const trailingEmpty = lastNonEmptyCol >= 0 ? totalCols - 1 - lastNonEmptyCol : totalCols;
+  
+  // Group header detection:
+  // - Has 1-2 non-empty cells at the start
+  // - Rest of the row is empty
+  // - Trailing empty cells >= half of total columns
+  const isGroupHeader = 
+    nonEmptyCount > 0 &&
+    nonEmptyCount <= 2 && 
+    lastNonEmptyCol < Math.min(2, Math.ceil(totalCols / 2)) &&
+    trailingEmpty >= Math.floor(totalCols / 2);
+  
+  // Valid tree row: no gap pattern and not completely empty
+  // But if gap only occurs in right portion (after column 2), still consider valid for tree
+  const isValidTreeRow = !isCompletelyEmpty && (!hasGap || gapStartCol >= Math.min(3, Math.ceil(totalCols / 2)));
+  
+  return {
+    rowIndex,
+    nonEmptyCount,
+    lastNonEmptyCol,
+    emptyPrefix,
+    isGroupHeader,
+    isValidTreeRow,
+    isCompletelyEmpty,
+    hasGap,
+    gapStartCol
+  };
+}
+
+/**
+ * Detect group header rows in the table
+ * 
+ * Group headers are rows where:
+ * 1. Only the first 1-2 columns have content
+ * 2. The rest of the columns are empty
+ * 3. They serve as section separators/titles
+ * 
+ * @param rows - 2D array of cell strings
+ * @returns Array of row indices that are group headers
+ * 
+ * @example
+ * ```typescript
+ * const rows = [
+ *   ['电子产品', '',   ''],      // ← Group header (index 0)
+ *   ['手机',    '10', '3000'],
+ *   ['电脑',    '5',  '5000'],
+ *   ['办公用品', '',   ''],      // ← Group header (index 3)
+ *   ['打印纸',  '100', '20'],
+ * ];
+ * const headers = detectGroupHeaders(rows);
+ * // headers = [0, 3]
+ * ```
+ */
+export function detectGroupHeaders(rows: string[][]): number[] {
+  const totalCols = rows[0]?.length || 0;
+  if (totalCols < 2) return [];
+  
+  const groupHeaders: number[] = [];
+  
+  for (let i = 0; i < rows.length; i++) {
+    const analysis = analyzeRow(rows[i], i, totalCols);
+    if (analysis.isGroupHeader) {
+      groupHeaders.push(i);
+    }
+  }
+  
+  return groupHeaders;
+}
+
+/**
+ * Check if a specific row is a group header
+ * 
+ * @param row - Single row of cell strings
+ * @param totalCols - Total number of columns in the table
+ * @returns true if the row is a group header
+ */
+export function isGroupHeaderRow(row: string[], totalCols?: number): boolean {
+  const cols = totalCols ?? row.length;
+  const analysis = analyzeRow(row, 0, cols);
+  return analysis.isGroupHeader;
+}
+
+// ============================================================================
+// Column Analysis
+// ============================================================================
+
+/**
+ * Extract merge segments from a column
+ */
+function extractColumnSegments(
+  rows: string[][],
+  colIndex: number,
+  skipRows: Set<number>
+): MergeSegment[] {
+  const segments: MergeSegment[] = [];
+  let currentSegment: MergeSegment | null = null;
+  
+  for (let row = 0; row < rows.length; row++) {
+    if (skipRows.has(row)) {
+      if (currentSegment) {
+        segments.push(currentSegment);
+        currentSegment = null;
+      }
+      continue;
+    }
+    
+    const value = rows[row]?.[colIndex];
+    const cellEmpty = isEmpty(value);
+    
+    if (!cellEmpty) {
+      if (currentSegment) {
+        segments.push(currentSegment);
+      }
+      currentSegment = { anchorRow: row, length: 1 };
+    } else if (currentSegment) {
+      currentSegment.length++;
+    }
+  }
+  
+  if (currentSegment) {
+    segments.push(currentSegment);
+  }
+  
+  return segments;
+}
+
+/**
+ * Analyze a column for tree structure
+ */
+function analyzeColumn(
+  rows: string[][],
+  colIndex: number,
+  skipRows: Set<number>
+): ColumnAnalysis {
+  const segments = extractColumnSegments(rows, colIndex, skipRows);
+  const effectiveRows = rows.length - skipRows.size;
+  
+  if (segments.length === 0 || effectiveRows <= 1) {
+    return {
+      colIndex,
+      segmentCount: 0,
+      maxSegmentLength: 0,
+      hasMultiRowSegment: false,
+      isTreeColumn: false
+    };
+  }
+  
+  const segmentCount = segments.length;
+  const maxSegmentLength = Math.max(...segments.map(s => s.length));
+  const hasMultiRowSegment = segments.some(s => s.length >= 2);
+  
+  // Tree column criteria (relaxed):
+  // 1. Has at least one multi-row segment (most important)
+  // 2. Segment count is reasonable (allow up to 90% of effective rows, was 80%)
+  // 3. First segment starts early (row 0, 1, or 2) - allow late start for tables
+  //    with leading empty cells in first column
+  // 4. OR: average segment length > 1.2 (shows meaningful grouping)
+  const avgSegmentLength = effectiveRows / segmentCount;
+  const isTreeColumn = 
+    hasMultiRowSegment &&
+    (segmentCount <= effectiveRows * 0.9 || avgSegmentLength > 1.2) &&
+    segments[0].anchorRow <= 2;
+  
+  return {
+    colIndex,
+    segmentCount,
+    maxSegmentLength,
+    hasMultiRowSegment,
+    isTreeColumn
+  };
+}
+
+// ============================================================================
+// Table Type Detection
+// ============================================================================
+
+/**
+ * Check if table is a comparison/feature table
+ */
+function isComparisonTable(rows: string[][]): boolean {
+  let markerCount = 0;
+  let totalCells = 0;
+  
+  for (const row of rows) {
+    for (const cell of row) {
+      totalCells++;
+      if (isMarkerSymbol(cell)) {
+        markerCount++;
+      }
+    }
+  }
+  
+  return totalCells > 0 && markerCount / totalCells > 0.3;
+}
+
+/**
+ * Check if table has sparse/random empty pattern
+ * A row is considered "sparse" if it has a gap in the left portion (tree columns)
+ */
+function isSparseTable(rowAnalyses: RowAnalysis[]): boolean {
+  // Count rows that are NOT valid tree rows (have gap in left columns)
+  const invalidTreeRows = rowAnalyses.filter(r => !r.isValidTreeRow && !r.isGroupHeader && !r.isCompletelyEmpty);
+  return invalidTreeRows.length / rowAnalyses.length > 0.3;
+}
+
+// ============================================================================
+// Main Analysis Functions
+// ============================================================================
+
+/**
+ * Analyze table structure comprehensively
+ * 
+ * This is the main entry point for table structure analysis.
+ * It determines the table type and whether cells should be merged.
+ * 
+ * @param rows - 2D array of cell strings (data rows only, excluding header)
+ * @returns Complete analysis result
+ * 
+ * @example
+ * ```typescript
+ * // Tree structure example
+ * const rows = [
+ *   ['研发部', '前端组', '张三'],
+ *   ['',       '',       '李四'],
+ *   ['',       '后端组', '王五'],
+ * ];
+ * const result = analyzeTableStructure(rows);
+ * // result.tableType = 'tree'
+ * // result.tree.columnCount = 2
+ * // result.shouldMerge = true
+ * 
+ * // Group header example
+ * const rows2 = [
+ *   ['水果类', '',     ''],
+ *   ['苹果',  '5元',  '红色'],
+ *   ['香蕉',  '3元',  '黄色'],
+ * ];
+ * const result2 = analyzeTableStructure(rows2);
+ * // result2.groupHeaders.rows = [0]
+ * // result2.groupHeaders.hasGroupHeaders = true
+ * ```
+ */
+export function analyzeTableStructure(rows: string[][]): TableAnalysisResult {
+  const totalRows = rows.length;
+  const totalCols = rows[0]?.length || 0;
+  
+  // Calculate empty stats
+  let emptyCount = 0;
+  for (const row of rows) {
+    for (const cell of row) {
+      if (isEmpty(cell)) emptyCount++;
+    }
+  }
+  const totalCells = totalRows * totalCols;
+  const emptyRatio = totalCells > 0 ? emptyCount / totalCells : 0;
+  
+  const baseStats = { totalRows, totalCols, emptyCount, emptyRatio };
+  
+  // Edge cases
+  if (totalRows === 0 || totalCols === 0 || totalRows === 1) {
+    return createNormalResult(baseStats);
+  }
+  
+  // Check for comparison table first
+  if (isComparisonTable(rows)) {
+    return createComparisonResult(baseStats);
+  }
+  
+  // Analyze all rows
+  const rowAnalyses = rows.map((row, idx) => analyzeRow(row, idx, totalCols));
+  
+  // Detect group headers
+  const groupHeaderRows = rowAnalyses
+    .filter(r => r.isGroupHeader)
+    .map(r => r.rowIndex);
+  const groupHeaderSet = new Set(groupHeaderRows);
+  const hasGroupHeaders = groupHeaderRows.length > 0;
+  
+  // Check for sparse pattern
+  if (isSparseTable(rowAnalyses)) {
+    return createSparseResult(baseStats, groupHeaderRows);
+  }
+  
+  // Calculate tree score
+  const nonHeaderRows = rowAnalyses.filter(r => !groupHeaderSet.has(r.rowIndex));
+  const validTreeRows = nonHeaderRows.filter(r => r.isValidTreeRow);
+  const treeScore = nonHeaderRows.length > 0
+    ? validTreeRows.length / nonHeaderRows.length
+    : 0;
+  
+  // Determine if it's a tree table
+  const isTreeTable = treeScore >= 0.8 && nonHeaderRows.length > 0;
+  
+  // Analyze columns for tree structure
+  const treeColumns: number[] = [];
+  if (isTreeTable) {
+    for (let col = 0; col < totalCols; col++) {
+      const colAnalysis = analyzeColumn(rows, col, groupHeaderSet);
+      if (colAnalysis.isTreeColumn) {
+        treeColumns.push(col);
+      }
+    }
+  }
+  
+  // Tree columns must be contiguous from the left
+  let treeColumnCount = 0;
+  for (let i = 0; i < treeColumns.length; i++) {
+    if (treeColumns[i] === i) {
+      treeColumnCount = i + 1;
+    } else {
+      break;
+    }
+  }
+  
+  const finalTreeColumns = treeColumns.slice(0, treeColumnCount);
+  const isValidTree = isTreeTable && treeColumnCount > 0;
+  
+  // Determine table type
+  let tableType: TableType;
+  if (isValidTree) {
+    tableType = 'tree';
+  } else if (hasGroupHeaders) {
+    tableType = 'grouped';
+  } else {
+    tableType = 'normal';
+  }
+  
+  return {
+    tableType,
+    shouldMerge: isValidTree,
+    tree: {
+      isTree: isValidTree,
+      columnCount: treeColumnCount,
+      columns: finalTreeColumns,
+      score: treeScore
+    },
+    groupHeaders: {
+      rows: groupHeaderRows,
+      hasGroupHeaders
+    },
+    stats: baseStats
+  };
+}
+
+/**
+ * Quick check if a table might need structure analysis
+ * Use this for early filtering before full analysis
+ * 
+ * @param rows - 2D array of cell strings
+ * @returns true if the table might need analysis
+ */
+export function mightNeedAnalysis(rows: string[][]): boolean {
+  if (rows.length < 2) return false;
+  
+  const totalCols = rows[0]?.length || 0;
+  if (totalCols < 2) return false;
+  
+  // Check if there are any empty cells
+  for (const row of rows) {
+    for (const cell of row) {
+      if (isEmpty(cell)) return true;
+    }
+  }
+  
+  return false;
+}
+
+// ============================================================================
+// Result Constructors
+// ============================================================================
+
+function createNormalResult(stats: TableAnalysisResult['stats']): TableAnalysisResult {
+  return {
+    tableType: 'normal',
+    shouldMerge: false,
+    tree: { isTree: false, columnCount: 0, columns: [], score: 0 },
+    groupHeaders: { rows: [], hasGroupHeaders: false },
+    stats
+  };
+}
+
+function createComparisonResult(stats: TableAnalysisResult['stats']): TableAnalysisResult {
+  return {
+    tableType: 'comparison',
+    shouldMerge: false,
+    tree: { isTree: false, columnCount: 0, columns: [], score: 0 },
+    groupHeaders: { rows: [], hasGroupHeaders: false },
+    stats
+  };
+}
+
+function createSparseResult(stats: TableAnalysisResult['stats'], groupHeaderRows: number[]): TableAnalysisResult {
+  return {
+    tableType: 'sparse',
+    shouldMerge: false,
+    tree: { isTree: false, columnCount: 0, columns: [], score: 0 },
+    groupHeaders: { rows: groupHeaderRows, hasGroupHeaders: groupHeaderRows.length > 0 },
+    stats
+  };
+}

--- a/markdown-sheet/src/lib/docx/theme-loader.ts
+++ b/markdown-sheet/src/lib/docx/theme-loader.ts
@@ -1,0 +1,397 @@
+/**
+ * Theme Loader for DOCX Export (Tauri environment)
+ * Simplified version combining theme-to-docx.ts + theme-manager.ts
+ * Loads theme JSON files via fetch() from public/themes/
+ */
+
+import { BorderStyle } from 'docx';
+import type {
+  DOCXThemeStyles,
+  DOCXRunStyle,
+  DOCXParagraphStyle,
+  DOCXParagraphSpacing,
+  DOCXHeadingStyle,
+  DOCXCharacterStyle,
+  DOCXTableStyle,
+  DOCXTableBorders,
+  DOCXBorder,
+  DOCXCodeColors,
+  BorderStyleValue,
+} from './types';
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface HeadingConfig {
+  fontFamily?: string;
+  fontWeight?: string;
+}
+
+interface FontScheme {
+  body: { fontFamily: string };
+  headings: {
+    fontFamily: string;
+    fontWeight?: string;
+    [key: string]: string | HeadingConfig | undefined;
+  };
+  code: { fontFamily: string };
+}
+
+interface ThemeConfig {
+  fontScheme: FontScheme;
+  layoutScheme: string;
+  colorScheme: string;
+  tableStyle: string;
+  codeTheme: string;
+}
+
+interface LayoutHeadingConfig {
+  fontSize: string;
+  spacingBefore: string;
+  spacingAfter: string;
+  alignment?: 'left' | 'center' | 'right';
+}
+
+interface LayoutBlockConfig {
+  spacingBefore?: string;
+  spacingAfter?: string;
+}
+
+interface LayoutScheme {
+  body: { fontSize: string; lineHeight: number };
+  headings: Record<string, LayoutHeadingConfig>;
+  code: { fontSize: string };
+  blocks: {
+    paragraph: LayoutBlockConfig;
+  };
+}
+
+interface ColorScheme {
+  text: { primary: string };
+  headings?: Record<string, string>;
+  background: { code: string };
+  accent: { link: string };
+  blockquote: { border: string };
+  table: {
+    border: string;
+    headerBackground: string;
+    headerText: string;
+    zebraEven: string;
+    zebraOdd: string;
+  };
+}
+
+interface BorderConfig {
+  style: string;
+  width: string;
+}
+
+interface TableStyleConfig {
+  border?: {
+    all?: BorderConfig;
+    headerTop?: BorderConfig;
+    headerBottom?: BorderConfig;
+    rowBottom?: BorderConfig;
+    lastRowBottom?: BorderConfig;
+  };
+  header: { fontWeight?: string };
+  cell: { padding: string };
+  zebra?: { enabled: boolean };
+}
+
+interface CodeThemeConfig {
+  colors: Record<string, string>;
+  foreground?: string;
+}
+
+interface FontConfig {
+  webFallback: string;
+  docx?: { ascii: string; eastAsia: string };
+}
+
+interface FontConfigFile {
+  fonts: Record<string, FontConfig>;
+}
+
+interface DocxFont {
+  ascii: string;
+  eastAsia: string;
+  hAnsi: string;
+  cs: string;
+}
+
+// ============================================================================
+// Local utility functions (replaces themeManager.ptToHalfPt etc.)
+// ============================================================================
+
+function ptToHalfPt(ptSize: string): number {
+  return parseFloat(ptSize) * 2;
+}
+
+function ptToTwips(ptSize: string | number): number {
+  const pt = typeof ptSize === 'number' ? ptSize : parseFloat(String(ptSize));
+  return Math.round(pt * 20);
+}
+
+let cachedFontConfig: FontConfigFile | null = null;
+
+async function loadFontConfig(): Promise<FontConfigFile> {
+  if (cachedFontConfig) return cachedFontConfig;
+  const resp = await fetch('/themes/font-config.json');
+  cachedFontConfig = await resp.json();
+  return cachedFontConfig!;
+}
+
+function getDocxFont(fontName: string, fontConfig: FontConfigFile): DocxFont {
+  const font = fontConfig.fonts[fontName];
+  if (!font || !font.docx) {
+    return { ascii: fontName, eastAsia: fontName, hAnsi: fontName, cs: fontName };
+  }
+  return {
+    ascii: font.docx.ascii,
+    eastAsia: font.docx.eastAsia,
+    hAnsi: font.docx.ascii,
+    cs: font.docx.ascii,
+  };
+}
+
+// ============================================================================
+// Style generation (from theme-to-docx.ts)
+// ============================================================================
+
+function generateDefaultStyle(
+  fontScheme: FontScheme,
+  layoutScheme: LayoutScheme,
+  fontConfig: FontConfigFile
+): { run: DOCXRunStyle; paragraph: DOCXParagraphStyle } {
+  const bodyFont = fontScheme.body.fontFamily;
+  const fontSize = ptToHalfPt(layoutScheme.body.fontSize);
+  const lineSpacing = Math.round(layoutScheme.body.lineHeight * 240);
+  const lineSpacingExtra = lineSpacing - 240;
+
+  const paragraphBlock = layoutScheme.blocks.paragraph;
+  const spacingBeforePt = parseFloat(paragraphBlock.spacingBefore || '0');
+  const spacingAfterPt = parseFloat(paragraphBlock.spacingAfter || '0');
+
+  const beforeSpacing = ptToTwips(spacingBeforePt) + Math.round(lineSpacingExtra / 2);
+  const afterSpacing = Math.max(0, ptToTwips(spacingAfterPt) - Math.round(lineSpacingExtra / 2));
+
+  const docxFont = getDocxFont(bodyFont, fontConfig);
+
+  return {
+    run: { font: docxFont, size: fontSize },
+    paragraph: {
+      spacing: { line: lineSpacing, before: beforeSpacing, after: afterSpacing },
+    },
+  };
+}
+
+function generateParagraphStyles(
+  fontScheme: FontScheme,
+  layoutScheme: LayoutScheme,
+  colorScheme: ColorScheme,
+  fontConfig: FontConfigFile
+): Record<string, DOCXHeadingStyle> {
+  const styles: Record<string, DOCXHeadingStyle> = {};
+  const headingLevels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+
+  headingLevels.forEach((level, index) => {
+    const headingLevel = index + 1;
+    const fontHeading = fontScheme.headings[level] as HeadingConfig | undefined;
+    const layoutHeading = layoutScheme.headings[level];
+
+    const font = fontHeading?.fontFamily || fontScheme.headings.fontFamily || fontScheme.body.fontFamily;
+    const docxFont = getDocxFont(font, fontConfig);
+    const headingFontWeight = fontHeading?.fontWeight ?? fontScheme.headings.fontWeight ?? 'bold';
+    const isBold = headingFontWeight === 'bold';
+
+    const headingBeforePt = parseFloat(layoutHeading.spacingBefore || '0');
+    const headingAfterPt = parseFloat(layoutHeading.spacingAfter || '0');
+    const lineSpacingExtra = 360 - 240;
+
+    const totalBefore = ptToTwips(headingBeforePt) + Math.round(lineSpacingExtra / 2);
+    const totalAfter = Math.max(0, ptToTwips(headingAfterPt) - Math.round(lineSpacingExtra / 2));
+
+    const headingColor = colorScheme.headings?.[level] || colorScheme.text.primary;
+
+    styles[`heading${headingLevel}`] = {
+      id: `Heading${headingLevel}`,
+      name: `Heading ${headingLevel}`,
+      basedOn: 'Normal',
+      next: 'Normal',
+      run: {
+        size: ptToHalfPt(layoutHeading.fontSize),
+        bold: isBold,
+        font: docxFont,
+        color: headingColor.replace('#', ''),
+      },
+      paragraph: {
+        spacing: { before: totalBefore, after: totalAfter, line: 360 },
+        alignment: layoutHeading.alignment || 'left',
+      },
+    };
+  });
+
+  return styles;
+}
+
+function generateCharacterStyles(
+  fontScheme: FontScheme,
+  layoutScheme: LayoutScheme,
+  colorScheme: ColorScheme,
+  fontConfig: FontConfigFile
+): { code: DOCXCharacterStyle } {
+  const codeFont = fontScheme.code.fontFamily;
+  const codeBackground = colorScheme.background.code.replace('#', '');
+  const docxFont = getDocxFont(codeFont, fontConfig);
+
+  return {
+    code: {
+      font: docxFont,
+      size: ptToHalfPt(layoutScheme.code.fontSize),
+      background: codeBackground,
+    },
+  };
+}
+
+function convertBorderStyle(cssStyle: string): BorderStyleValue {
+  const styleMap: Record<string, BorderStyleValue> = {
+    none: BorderStyle.NONE,
+    solid: BorderStyle.SINGLE,
+    dashed: BorderStyle.DASHED,
+    dotted: BorderStyle.DOTTED,
+    double: BorderStyle.DOUBLE,
+  };
+  return styleMap[cssStyle] || BorderStyle.SINGLE;
+}
+
+function parseBorderWidth(width: string): number {
+  const match = width.match(/^(\d+\.?\d*)(pt|px)$/);
+  if (!match) return 8;
+  const value = parseFloat(match[1]);
+  const unit = match[2];
+  if (unit === 'pt') return Math.round(value * 8);
+  if (unit === 'px') return Math.round(value * 0.75 * 8);
+  return 8;
+}
+
+function generateTableStyles(tableStyle: TableStyleConfig, colorScheme: ColorScheme): DOCXTableStyle {
+  const docxTableStyle: DOCXTableStyle = {
+    borders: {},
+    header: {},
+    cell: {},
+    zebra: tableStyle.zebra?.enabled || false,
+  };
+
+  const borderColor = colorScheme.table.border.replace('#', '');
+  const border = tableStyle.border || {};
+
+  if (border.all) {
+    docxTableStyle.borders.all = {
+      style: convertBorderStyle(border.all.style),
+      size: parseBorderWidth(border.all.width),
+      color: borderColor,
+    };
+  }
+  if (border.headerTop) {
+    docxTableStyle.borders.headerTop = {
+      style: convertBorderStyle(border.headerTop.style),
+      size: parseBorderWidth(border.headerTop.width),
+      color: borderColor,
+    };
+  }
+  if (border.headerBottom) {
+    docxTableStyle.borders.headerBottom = {
+      style: convertBorderStyle(border.headerBottom.style),
+      size: parseBorderWidth(border.headerBottom.width),
+      color: borderColor,
+    };
+  }
+  if (border.rowBottom) {
+    docxTableStyle.borders.insideHorizontal = {
+      style: convertBorderStyle(border.rowBottom.style),
+      size: parseBorderWidth(border.rowBottom.width),
+      color: borderColor,
+    };
+  }
+  if (border.lastRowBottom) {
+    docxTableStyle.borders.lastRowBottom = {
+      style: convertBorderStyle(border.lastRowBottom.style),
+      size: parseBorderWidth(border.lastRowBottom.width),
+      color: borderColor,
+    };
+  }
+
+  docxTableStyle.header.shading = { fill: colorScheme.table.headerBackground.replace('#', '') };
+  docxTableStyle.header.color = colorScheme.table.headerText.replace('#', '');
+  if (tableStyle.header.fontWeight) {
+    docxTableStyle.header.bold = tableStyle.header.fontWeight === 'bold';
+  }
+
+  const paddingTwips = ptToTwips(tableStyle.cell.padding);
+  docxTableStyle.cell.margins = {
+    top: paddingTwips,
+    bottom: paddingTwips,
+    left: paddingTwips,
+    right: paddingTwips,
+  };
+
+  if (tableStyle.zebra?.enabled) {
+    docxTableStyle.zebra = {
+      even: colorScheme.table.zebraEven.replace('#', ''),
+      odd: colorScheme.table.zebraOdd.replace('#', ''),
+    };
+  }
+
+  return docxTableStyle;
+}
+
+function generateCodeColors(codeTheme: CodeThemeConfig, colorScheme: ColorScheme): DOCXCodeColors {
+  const colorMap: Record<string, string> = {};
+  Object.keys(codeTheme.colors).forEach((token) => {
+    colorMap[token] = codeTheme.colors[token];
+  });
+
+  return {
+    background: colorScheme.background.code.replace('#', ''),
+    foreground: codeTheme.foreground?.replace('#', '') || '24292e',
+    colors: colorMap,
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Load theme and generate DOCX styles
+ * Uses fetch() to load theme JSON files from public/themes/
+ * @param themeId - Theme preset ID (default: 'default')
+ * @returns Complete DOCX theme styles
+ */
+export async function loadThemeForDOCX(themeId = 'default'): Promise<DOCXThemeStyles> {
+  const fontConfig = await loadFontConfig();
+
+  // Load theme preset
+  const themeResp = await fetch(`/themes/presets/${themeId}.json`);
+  const theme: ThemeConfig = await themeResp.json();
+
+  // Load sub-resources in parallel
+  const [layoutScheme, colorScheme, tableStyle, codeTheme] = await Promise.all([
+    fetch(`/themes/layout-schemes/${theme.layoutScheme}.json`).then((r) => r.json()) as Promise<LayoutScheme>,
+    fetch(`/themes/color-schemes/${theme.colorScheme}.json`).then((r) => r.json()) as Promise<ColorScheme>,
+    fetch(`/themes/table-styles/${theme.tableStyle}.json`).then((r) => r.json()) as Promise<TableStyleConfig>,
+    fetch(`/themes/code-themes/${theme.codeTheme}.json`).then((r) => r.json()) as Promise<CodeThemeConfig>,
+  ]);
+
+  return {
+    default: generateDefaultStyle(theme.fontScheme, layoutScheme, fontConfig),
+    paragraphStyles: generateParagraphStyles(theme.fontScheme, layoutScheme, colorScheme, fontConfig),
+    characterStyles: generateCharacterStyles(theme.fontScheme, layoutScheme, colorScheme, fontConfig),
+    tableStyles: generateTableStyles(tableStyle, colorScheme),
+    codeColors: generateCodeColors(codeTheme, colorScheme),
+    linkColor: colorScheme.accent.link.replace('#', ''),
+    blockquoteColor: colorScheme.blockquote.border.replace('#', ''),
+  };
+}

--- a/markdown-sheet/src/lib/docx/types.ts
+++ b/markdown-sheet/src/lib/docx/types.ts
@@ -1,0 +1,293 @@
+/**
+ * DOCX Export Type Definitions
+ * 
+ * This file defines types for DOCX export functionality.
+ * 
+ * IMPORTANT: These types are INTERNAL types for theme configuration and conversion.
+ * They are NOT the same as docx library types. The conversion layer (theme-to-docx.ts)
+ * is responsible for converting these internal types to docx library types.
+ */
+
+import { BorderStyle, AlignmentType, type IFontAttributesProperties } from 'docx';
+
+// =============================================================================
+// Type Helpers - Extract value types from docx const objects
+// =============================================================================
+
+/**
+ * Alignment type values from docx library
+ * Use this type when you need to store alignment values
+ */
+export type AlignmentTypeValue = (typeof AlignmentType)[keyof typeof AlignmentType];
+
+/**
+ * Border style values from docx library
+ * Use this type when you need to store border style values
+ */
+export type BorderStyleValue = (typeof BorderStyle)[keyof typeof BorderStyle];
+
+// =============================================================================
+// Emoji Style Configuration
+// =============================================================================
+
+/**
+ * Emoji font style options for DOCX export
+ * - 'apple': Use Apple Color Emoji (iOS/macOS style, 3D glossy)
+ * - 'windows': Use Segoe UI Emoji (Windows/WPS style, flat design)
+ * - 'system': Use system emoji (no font processing, preserve original)
+ */
+export type EmojiStyle = 'apple' | 'windows' | 'system';
+
+// =============================================================================
+// Internal Theme Styles - Used by theme-to-docx conversion
+// =============================================================================
+
+/**
+ * Internal run style for theme configuration
+ * This is converted to IRunStylePropertiesOptions when creating DOCX
+ */
+export interface DOCXRunStyle {
+  font: string | IFontAttributesProperties;
+  size: number;  // In half-points (e.g., 24 = 12pt)
+  bold?: boolean;
+  color?: string;  // Hex color without #
+}
+
+/**
+ * Internal paragraph spacing for theme configuration
+ * Values are in twips (twentieth of a point, 1440 twips = 1 inch)
+ */
+export interface DOCXParagraphSpacing {
+  line?: number;
+  before?: number;
+  after?: number;
+}
+
+/**
+ * Internal paragraph style for theme configuration
+ * Note: alignment is stored as string for flexibility in theme files,
+ * converted to AlignmentTypeValue at runtime
+ */
+export interface DOCXParagraphStyle {
+  spacing?: DOCXParagraphSpacing;
+  alignment?: string;  // 'left' | 'center' | 'right' - converted at runtime
+}
+
+/**
+ * Internal heading style for theme configuration
+ */
+export interface DOCXHeadingStyle {
+  id: string;
+  name: string;
+  basedOn: string;
+  next: string;
+  run: DOCXRunStyle;
+  paragraph: DOCXParagraphStyle;
+}
+
+/**
+ * Internal character style for code blocks
+ */
+export interface DOCXCharacterStyle {
+  font: string | IFontAttributesProperties;
+  size: number;
+  background: string;  // Hex color without #
+}
+
+/**
+ * Internal border style
+ * Note: style is BorderStyleValue from docx library
+ */
+export interface DOCXBorder {
+  style: BorderStyleValue;
+  size: number;
+  color: string;  // Hex color without #
+}
+
+/**
+ * Internal table borders configuration
+ */
+export interface DOCXTableBorders {
+  all?: DOCXBorder;
+  headerTop?: DOCXBorder;
+  headerBottom?: DOCXBorder;
+  insideHorizontal?: DOCXBorder;
+  lastRowBottom?: DOCXBorder;
+}
+
+/**
+ * Internal table style configuration
+ */
+export interface DOCXTableStyle {
+  borders: DOCXTableBorders;
+  header: {
+    shading?: { fill: string };
+    color?: string;  // Header text color (hex without #)
+    bold?: boolean;
+  };
+  cell: {
+    margins?: {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    };
+  };
+  zebra: boolean | {
+    even: string;
+    odd: string;
+  };
+}
+
+/**
+ * Code syntax highlighting colors
+ */
+export interface DOCXCodeColors {
+  background: string;  // Hex color without #
+  foreground: string;  // Hex color without #
+  colors: Record<string, string>;  // Token type -> hex color
+}
+
+/**
+ * Complete internal DOCX theme styles configuration
+ * Used throughout the DOCX export system
+ */
+export interface DOCXThemeStyles {
+  default: {
+    run: DOCXRunStyle;
+    paragraph: DOCXParagraphStyle;
+  };
+  paragraphStyles: Record<string, DOCXHeadingStyle>;
+  characterStyles: {
+    code: DOCXCharacterStyle;
+  };
+  tableStyles: DOCXTableStyle;
+  codeColors: DOCXCodeColors;
+  linkColor: string;  // Link color from colorScheme (hex without #)
+  blockquoteColor: string;  // Blockquote left border color from colorScheme (hex without #)
+}
+
+// =============================================================================
+// DOCX Converter Types
+// =============================================================================
+
+/**
+ * Link definition from markdown reference links
+ */
+export interface LinkDefinition {
+  url: string;
+  title: string | null;  // null when not specified
+}
+
+/**
+ * Image buffer result from fetching
+ */
+export interface ImageBufferResult {
+  buffer: Uint8Array;
+  contentType: string;
+}
+
+/**
+ * Supported image types for DOCX
+ */
+export type DOCXImageType = 'png' | 'jpg' | 'gif' | 'bmp';
+
+/**
+ * Fetch image result with dimensions
+ */
+export interface FetchImageResult {
+  buffer: Uint8Array;
+  width: number;
+  height: number;
+  type: DOCXImageType;
+}
+
+/**
+ * DOCX export result
+ */
+export interface DOCXExportResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Progress callback type
+ */
+export type DOCXProgressCallback = (processed: number, total: number) => void;
+
+/**
+ * Public DOCX exporter interface
+ * Implemented by the DocxExporter class in src/exporters/docx-exporter.ts
+ */
+export interface DocxExporter {
+  exportToDocx(
+    markdown: string,
+    filename?: string,
+    onProgress?: DOCXProgressCallback | null
+  ): Promise<DOCXExportResult>;
+  setBaseUrl?(url: string): void;
+}
+
+// =============================================================================
+// AST Node Types for DOCX conversion
+// =============================================================================
+
+/**
+ * Base AST node interface
+ */
+export interface DOCXASTNode {
+  type: string;
+  children?: DOCXASTNode[];
+  value?: string;
+  depth?: number;
+  lang?: string;
+  url?: string;
+  title?: string;
+  identifier?: string;
+  ordered?: boolean;
+  start?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * List node with ordering info
+ */
+export interface DOCXListNode extends DOCXASTNode {
+  type: 'list';
+  ordered: boolean;
+  start?: number;
+  children: DOCXASTNode[];
+}
+
+/**
+ * Blockquote node
+ */
+export interface DOCXBlockquoteNode extends DOCXASTNode {
+  type: 'blockquote';
+  children: DOCXASTNode[];
+}
+
+/**
+ * Table node
+ */
+export interface DOCXTableNode extends DOCXASTNode {
+  type: 'table';
+  children: DOCXASTNode[];  // Table rows
+}
+
+/**
+ * Inline node (text, link, emphasis, etc.)
+ */
+export interface DOCXInlineNode extends DOCXASTNode {
+  type: 'text' | 'link' | 'emphasis' | 'strong' | 'inlineCode' | 'image' | 'linkReference' | 'inlineMath' | 'break' | 'html';
+  url?: string;
+  title?: string;
+  identifier?: string;
+  alt?: string;
+}
+
+// =============================================================================
+// Re-export for convenience
+// =============================================================================
+
+export { BorderStyle, AlignmentType };

--- a/markdown-sheet/src/types.ts
+++ b/markdown-sheet/src/types.ts
@@ -55,7 +55,7 @@ export interface AiSettings {
   apiKey: string;
   model: string;
   baseUrl: string;
-  apiFormat: "openai" | "anthropic";
+  apiFormat: "openai" | "anthropic" | "azure";
 }
 
 /** エディタタブ1つ分の保存状態 */

--- a/markdown-sheet/vite.config.ts
+++ b/markdown-sheet/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(async () => ({
       : undefined,
   },
   optimizeDeps: {
-    include: ["mermaid", "highlight.js"],
+    include: ["mermaid", "highlight.js", "docx"],
     exclude: [
       "@tauri-apps/api",
       "@tauri-apps/plugin-dialog",


### PR DESCRIPTION
## Summary

- MarkdownからDOCX形式へのエクスポート機能を追加
- UIプレビューで選択したフォント（メイリオ、游ゴシック等）をDOCXに反映                                                                                                                       - Mermaidダイアグラムをプレビュー DOMからSVG→PNG変換してDOCXに埋め込み                                                                                                                    

## Attribution

DOCX出力の実装は [markdown-viewer-extension](https://github.com/markdown-viewer/markdown-viewer-extension)（GPLv3）のコードを一部流用しています。

## Test plan

- [✔] 各フォント（メイリオ、游ゴシック、游明朝等）を選択してDOCXエクスポートし、フォントが正しく反映されることを確認
- [✔] Mermaidダイアグラムを含むMarkdownをDOCXエクスポートし、画像として埋め込まれることを確認
- [✔] 画像・テーブル・数式など他の要素が正常にエクスポートされることを確認
   
   🤖 Generated with [Claude Code](https://claude.com/claude-code)